### PR TITLE
fix(setup): register slash commands and add missing quick-install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ python bootstrap_vault.py --path ~/my-vault --name "Your Name" --style obsidian
 One line:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/eugeniughelbur/obsidian-second-brain/main/scripts/quick-install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/eugeniughelbur/obsidian-second-brain/main/scripts/quick-install.sh | bash
 ```
 
 Or two commands:

--- a/scripts/quick-install.sh
+++ b/scripts/quick-install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# quick-install.sh — one-liner installer for obsidian-second-brain
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/eugeniughelbur/obsidian-second-brain/main/scripts/quick-install.sh | bash
+#
+# What it does:
+#   1. Clones the repo to ~/.claude/skills/obsidian-second-brain (or pulls if it exists)
+#   2. Prompts for the vault path
+#   3. Runs scripts/setup.sh with that path
+#
+# Environment:
+#   OBSIDIAN_VAULT_PATH — skip the prompt and use this path
+#   SKILL_DIR           — override the install location (default: ~/.claude/skills/obsidian-second-brain)
+
+set -euo pipefail
+
+REPO_URL="https://github.com/eugeniughelbur/obsidian-second-brain"
+SKILL_DIR="${SKILL_DIR:-$HOME/.claude/skills/obsidian-second-brain}"
+
+red()    { printf '\033[0;31m%s\033[0m\n' "$1"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$1"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$1"; }
+
+if ! command -v git &>/dev/null; then
+  red "Error: git not found. Install git and retry."
+  exit 1
+fi
+
+# ── clone or update ──────────────────────────────────────────────────────────
+
+if [[ -d "$SKILL_DIR/.git" ]]; then
+  yellow "Repo already at $SKILL_DIR — pulling latest..."
+  git -C "$SKILL_DIR" pull --ff-only
+else
+  if [[ -e "$SKILL_DIR" ]]; then
+    red "Error: $SKILL_DIR exists and is not a git checkout. Move it aside first."
+    exit 1
+  fi
+  mkdir -p "$(dirname "$SKILL_DIR")"
+  git clone "$REPO_URL" "$SKILL_DIR"
+fi
+
+green "Skill installed at $SKILL_DIR"
+
+# ── resolve vault path ───────────────────────────────────────────────────────
+
+VAULT="${OBSIDIAN_VAULT_PATH:-}"
+
+if [[ -z "$VAULT" ]]; then
+  if [[ ! -t 0 ]]; then
+    yellow ""
+    yellow "Vault path required. Re-run with OBSIDIAN_VAULT_PATH set, or run setup.sh directly:"
+    echo "  bash $SKILL_DIR/scripts/setup.sh \"/path/to/your/vault\""
+    exit 0
+  fi
+  printf "Path to your Obsidian vault: "
+  read -r VAULT
+fi
+
+# ── hand off to setup.sh ─────────────────────────────────────────────────────
+
+bash "$SKILL_DIR/scripts/setup.sh" "$VAULT"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,8 @@
 #   2. Adds OBSIDIAN_VAULT_PATH to ~/.claude/settings.json
 #   3. Wires the PostCompact background agent hook
 #   4. Makes the hook script executable
-#   5. Configures the MCP server for Claude Code (optional)
+#   5. Registers slash commands in ~/.claude/commands/
+#   6. Configures the MCP server for Claude Code (optional)
 
 set -euo pipefail
 
@@ -108,9 +109,42 @@ else
   green "   PostCompact hook wired"
 fi
 
+# ── register slash commands ──────────────────────────────────────────────────
+
+step "3. Registering slash commands in ~/.claude/commands/..."
+
+COMMANDS_SRC="$SKILL_DIR/commands"
+COMMANDS_DST="$HOME/.claude/commands"
+
+if [[ ! -d "$COMMANDS_SRC" ]]; then
+  yellow "   No commands/ directory in skill — skipping"
+else
+  mkdir -p "$COMMANDS_DST"
+  linked=0
+  skipped=0
+  blocked=0
+  for cmd in "$COMMANDS_SRC"/*.md; do
+    [[ -e "$cmd" ]] || continue
+    name=$(basename "$cmd")
+    target="$COMMANDS_DST/$name"
+    if [[ -L "$target" ]]; then
+      # already a symlink — refresh it (idempotent, handles repo path changes)
+      ln -snf "$cmd" "$target"
+      skipped=$((skipped + 1))
+    elif [[ -e "$target" ]]; then
+      yellow "   Skipped $name — file already exists (not a symlink). Remove it manually if you want the skill version."
+      blocked=$((blocked + 1))
+    else
+      ln -s "$cmd" "$target"
+      linked=$((linked + 1))
+    fi
+  done
+  green "   $linked new, $skipped refreshed, $blocked blocked"
+fi
+
 # ── optional: MCP server (Claude Code only) ───────────────────────────────────
 
-step "3. MCP server (optional — Claude Code only)..."
+step "4. MCP server (optional — Claude Code only)..."
 echo "   The obsidian-vault MCP server gives Claude faster vault access."
 echo "   Without it, Claude reads/writes vault files directly (works fine)."
 echo ""


### PR DESCRIPTION
Fixes #4.

## Summary

Three install bugs that together make the documented quick-install path return `Unknown command: /obsidian-init` on a fresh setup:

1. **`scripts/quick-install.sh` was missing.** The README one-liner pipes `https://raw.githubusercontent.com/.../scripts/quick-install.sh` into `bash`. The file doesn't exist on `main`, so GitHub returns a `404` text body, `curl -sL` hides the HTTP error, and `bash` runs the HTML — `bash: line 1: 404:: command not found`. Adds the script: clones the repo (or pulls if already present), resolves the vault path from `OBSIDIAN_VAULT_PATH` or a TTY prompt, then hands off to `setup.sh`.

2. **`setup.sh` never registered slash commands.** After running it, `~/.claude/commands/` contains no `obsidian-*` entries, so every command in the README "Commands" table fails. Adds an idempotent symlink step that links each `commands/*.md` into `~/.claude/commands/`. Refreshes stale symlinks (handles repo-path moves), skips real files with a warning so user-authored commands aren't clobbered.

3. **README one-liner used `curl -sL`.** Switched to `curl -fsSL` so the next time a referenced URL goes 404, the install aborts with a real error instead of piping HTML into a shell.

## Test plan

- [x] `bash -n scripts/setup.sh` and `bash -n scripts/quick-install.sh` — syntax clean.
- [x] Re-ran the symlink step against an environment that already had all 31 symlinks: `linked=0 skipped=31 blocked=0` — fully idempotent.
- [x] Verified each `commands/*.md` resolves to a `/obsidian-*` slash command after symlinking.
- [ ] Maintainer to run on a fresh machine — happy to adjust if the prompt UX or path-resolution differs from what you'd want.

## Notes for the maintainer

- I didn't touch `bootstrap_vault.py`, `vault_health.py`, or any of the `commands/*.md` content.
- Did not bump `setup.sh`'s step numbering in the comment header beyond inserting "5. Registers slash commands" — happy to renumber differently if you prefer.
- Public install instructions still point at `eugeniughelbur/obsidian-second-brain/main`; nothing in the patch hard-codes my fork.
