### PR TITLE
fix: Windows compatibility (preserve NTFS hardlinks and remove dead python3 call)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -72,11 +72,9 @@ fi
 
 # ── add env var ───────────────────────────────────────────────────────────────
 
-ESCAPED_VAULT=$(printf '%s' "$VAULT" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" | tr -d '"')
-
 jq --arg vault "$VAULT" '
   .env = (.env // {}) | .env.OBSIDIAN_VAULT_PATH = $vault
-' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
 
 green "   OBSIDIAN_VAULT_PATH set"
 
@@ -105,7 +103,7 @@ else
         "async": true
       }]
     }]
-  ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+  ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
   green "   PostCompact hook wired"
 fi
 


### PR DESCRIPTION
What this PR does
This PR improves Windows compatibility and reliability by addressing two critical issues in the setup process:

Preserves NTFS Hardlinks: Replaced mv with cat for updating settings.json. On Windows, mv replaces the file and destroys existing Hardlinks (common in "Single Source of Truth" setups). Using redirection (cat >) truncates the file in place, preserving the inode and all associated links.

Fixes Microsoft Store Trigger: Removed the explicit python3 check that frequently triggers the "Microsoft Store" launcher stub on Windows machines where Python is not in the PATH, causing the setup to hang or fail.

Type of change
[x] 🐛 Bug fix (non-breaking change that fixes an issue)
[x] 🧹 Refactor / cleanup

Related issues
n/a (Technical optimization for Windows environments)

How I tested it
Environment: Windows 11, PowerShell 7, Git Bash.

Hardlink Test: Created a hardlink for settings.json in a separate config folder. Ran setup.sh. Verified the link count remained at 2 and the inode was unchanged after the update.

Execution Test: Verified the script no longer attempts to open the Microsoft Store on a clean Windows environment.

AI-first rule compliance
[x] My changes follow references/ai-first-rules.md (Technical infrastructure only)

Checklist
[x] I searched existing issues and PRs before opening this one
[x] My commit messages are descriptive (focus on WHY, not just WHAT)
[x] I updated the README or docs if user-facing behavior changed


Note for reviewer: The change from mv to cat is a standard POSIX-compliant way to update files while respecting hardlinks, ensuring that users syncing their ~/.claude/settings.json with a dotfiles repository don't have their links broken.