### PR TITLE
Read research vault path from OBSIDIAN_VAULT_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Copy this file to ~/.config/obsidian-second-brain/.env and fill in the values.
 # That path is Mac-local — never committed, never synced. Set permissions 600.
 
+# ─── Vault location (required) ──────────────────────────────
+# Absolute path to your Obsidian vault root. Research notes save here.
+OBSIDIAN_VAULT_PATH=
+
 # ─── xAI Grok ───────────────────────────────────────────────
 # Powers /x-read and /x-pulse (live X reading + trend analysis)
 # Get key: https://console.x.ai

--- a/scripts/research/lib/config.py
+++ b/scripts/research/lib/config.py
@@ -35,5 +35,5 @@ PERPLEXITY_RESEARCH_MODEL = get_optional("PERPLEXITY_RESEARCH_MODEL", "sonar-pro
 PERPLEXITY_DEEP_MODEL = get_optional("PERPLEXITY_DEEP_MODEL", "sonar-deep-research")
 NOTEBOOKLM_MODEL = get_optional("NOTEBOOKLM_MODEL", "gemini-2.5-flash")
 
-VAULT_PATH = Path.home() / "Projects" / "personal" / "obsinian" / "Eugeniu's Vault"
+VAULT_PATH = Path(get_required("OBSIDIAN_VAULT_PATH")).expanduser()
 USAGE_LOG = Path.home() / ".research-toolkit" / "usage.log"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SETTINGS="$HOME/.claude/settings.json"
 HOOK_SCRIPT="$SKILL_DIR/hooks/obsidian-bg-agent.sh"
+ENV_FILE="$HOME/.config/obsidian-second-brain/.env"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -77,6 +78,16 @@ jq --arg vault "$VAULT" '
 ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
 
 green "   OBSIDIAN_VAULT_PATH set"
+
+# Wire the vault path into the research toolkit .env so standalone runs resolve it
+if [ -f "$ENV_FILE" ]; then
+  VAULT="$VAULT" awk '
+    /^OBSIDIAN_VAULT_PATH=/ { print "OBSIDIAN_VAULT_PATH=" ENVIRON["VAULT"]; done=1; next }
+    { print }
+    END { if (!done) print "OBSIDIAN_VAULT_PATH=" ENVIRON["VAULT"] }
+  ' "$ENV_FILE" > "$ENV_FILE.tmp" && mv "$ENV_FILE.tmp" "$ENV_FILE"
+  green "   OBSIDIAN_VAULT_PATH written to research .env"
+fi
 
 # ── add PostCompact hook ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
The research toolkit hardcoded VAULT_PATH to a personal path in scripts/research/lib/config.py, so every other user's /youtube, /research, /research-deep and /notebooklm notes saved into a nonexistent vault and the printed obsidian:// links failed to resolve.

This reads the path from OBSIDIAN_VAULT_PATH — already the project-wide convention (hooks, setup.sh, quick-install.sh, SKILL.md) — via the existing get_required helper, so a missing value fails fast with the standard message instead of silently saving to the wrong place. .env.example documents it as required, and setup.sh now also writes it into the research .env, so it resolves on standalone CLI runs and not only when it is already present in the environment.