### PR TITLE
Feat/sessionstart hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ __pycache__/
 
 # Build output (regenerate with `bash scripts/build.sh`)
 dist/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Local config (never commit)
 .env
 *.local
+.claude/
 
 # macOS
 .DS_Store
@@ -21,4 +22,3 @@ __pycache__/
 
 # Build output (regenerate with `bash scripts/build.sh`)
 dist/
-.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **SessionStart hook (`hooks/load_vault_context.py`):** injects `_CLAUDE.md` into context once per session when the session starts inside the vault. Eliminates the per-command re-read of `_CLAUDE.md` that burned tokens on every invocation. Wired automatically by `scripts/setup.sh`.
+- **`scripts/setup.sh` updated:** wires the new SessionStart hook (`hooks/load_vault_context.py`) in addition to the existing PostCompact background agent.
+
 ## [0.8.0] — 2026-05-15
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,10 @@ description: >
 
 Try these methods in order. Use the first one available:
 
+**Method 0 — SessionStart hook (if configured):**
+If `hooks/load_vault_context.py` is wired as a SessionStart hook in `~/.claude/settings.json`, `_CLAUDE.md` is injected into context automatically at session start. Skip step 1 below.
+To wire it: `bash scripts/setup.sh "/path/to/vault"` or run `/obsidian-setup`.
+
 **Method A — MCP server (`mcp-obsidian`):**
 If the MCP tools (`get_file_contents`, `list_files_in_vault`, `search`, `append_content`, `write_file`) are available, use them.
 
@@ -51,6 +55,8 @@ get_file_contents("_CLAUDE.md")
 
 If it exists: follow its rules exactly — they override the defaults in this skill. Where `_CLAUDE.md` is silent, fall back to the defaults below.
 If it doesn't exist: use the defaults in this skill, then offer to create one.
+
+If the SessionStart hook is active, `_CLAUDE.md` is already in context — skip this step.
 
 ### 2. First time with a new user → run discovery
 

--- a/hooks/load_vault_context.py
+++ b/hooks/load_vault_context.py
@@ -57,14 +57,13 @@ def main() -> int:
 
     content = claude_md.read_text(encoding="utf-8")
 
+    v = Path(vault)
     header = (
         f"**Vault root**: `{vault}`\n"
         f"**Key files** (absolute paths — use these directly, no discovery needed):\n"
-        f"  - `{vault}\\_CLAUDE.md` — this operating manual (already loaded)\n"
-        f"  - `{vault}\\index.md` — navigation hub + live Bases links + stats\n"
-        f"  - `{vault}\\log.md` — pointer to per-day logs\n"
-        f"  - `{vault}\\Logs\\YYYY-MM-DD.md` — today's operations log\n"
-        f"  - `{vault}\\Projects\\_Projects.base` — live project view\n"
+        f"  - `{v / '_CLAUDE.md'}` — this operating manual (already loaded)\n"
+        f"  - `{v / 'index.md'}` — navigation hub\n"
+        f"  - `{v / 'log.md'}` — operation log\n"
         "**Do NOT run `ls`, `Glob`, or `Bash` to discover the vault or its folders.**\n"
         "Use the vault root path above and the folder names from the manual below directly.\n\n"
         "---\n\n"

--- a/hooks/load_vault_context.py
+++ b/hooks/load_vault_context.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject _CLAUDE.md into context once per session.
+
+Gated to the AI-Brain vault: fires only when the session's cwd is inside
+$OBSIDIAN_VAULT_PATH. Skips silently otherwise (any output would land in
+the model's context for non-vault sessions, which is not what we want).
+
+Setup:
+    1. Set OBSIDIAN_VAULT_PATH in ~/.claude/settings.json env section
+    2. Register as a SessionStart hook in ~/.claude/settings.json:
+         { "type": "command",
+           "command": "python ~/.claude/skills/obsidian-second-brain/hooks/load_vault_context.py" }
+
+Path normalization handles Windows ("C:\\..."), MSYS ("/c/..."), and POSIX
+("/...") — match works regardless of which form the harness or env var uses.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def normalize(p: str) -> str:
+    """Lowercase drive letter, forward slashes, no trailing slash."""
+    if not p:
+        return ""
+    p = p.replace("\\", "/")
+    m = re.match(r"^([A-Za-z]):(.*)$", p)
+    if m:
+        p = f"/{m.group(1).lower()}{m.group(2)}"
+    return p.rstrip("/")
+
+
+def main() -> int:
+    vault = os.environ.get("OBSIDIAN_VAULT_PATH", "")
+    if not vault:
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    cwd = payload.get("cwd", "")
+    vault_n = normalize(vault)
+    cwd_n = normalize(cwd)
+
+    if not (cwd_n == vault_n or cwd_n.startswith(vault_n + "/")):
+        return 0
+
+    claude_md = Path(vault) / "_CLAUDE.md"
+    if not claude_md.is_file():
+        return 0
+
+    content = claude_md.read_text(encoding="utf-8")
+
+    header = (
+        f"**Vault root**: `{vault}`\n"
+        f"**Key files** (absolute paths — use these directly, no discovery needed):\n"
+        f"  - `{vault}\\_CLAUDE.md` — this operating manual (already loaded)\n"
+        f"  - `{vault}\\index.md` — navigation hub + live Bases links + stats\n"
+        f"  - `{vault}\\log.md` — pointer to per-day logs\n"
+        f"  - `{vault}\\Logs\\YYYY-MM-DD.md` — today's operations log\n"
+        f"  - `{vault}\\Projects\\_Projects.base` — live project view\n"
+        "**Do NOT run `ls`, `Glob`, or `Bash` to discover the vault or its folders.**\n"
+        "Use the vault root path above and the folder names from the manual below directly.\n\n"
+        "---\n\n"
+        "Vault operating manual (_CLAUDE.md, loaded once at session start "
+        "by the load_vault_context hook — do not re-read on each command):\n\n"
+    )
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": header + content,
+        }
+    }
+    json.dump(output, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SETTINGS="$HOME/.claude/settings.json"
 HOOK_SCRIPT="$SKILL_DIR/hooks/obsidian-bg-agent.sh"
+SESSION_HOOK="$SKILL_DIR/hooks/load_vault_context.py"
 ENV_FILE="$HOME/.config/obsidian-second-brain/.env"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -52,9 +53,11 @@ echo ""
 
 # ── make hook executable ──────────────────────────────────────────────────────
 
-step "1. Making hook script executable..."
+step "1. Making hook scripts executable..."
 chmod +x "$HOOK_SCRIPT"
+[[ -f "$SESSION_HOOK" ]] && chmod +x "$SESSION_HOOK"
 green "   Done — $HOOK_SCRIPT"
+green "   Done — $SESSION_HOOK"
 
 # ── ensure settings.json exists ───────────────────────────────────────────────
 
@@ -116,6 +119,32 @@ else
     }]
   ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
   green "   PostCompact hook wired"
+fi
+
+# ── add SessionStart hook ────────────────────────────────────────────────────
+
+SESSION_HOOK_CMD="python $SESSION_HOOK"
+
+EXISTING_SESSION=$(jq -r '
+  .hooks.SessionStart // [] |
+  .[].hooks // [] |
+  .[].command // ""
+' "$SETTINGS" 2>/dev/null | grep -F "$SESSION_HOOK" || true)
+
+if [[ -n "$EXISTING_SESSION" ]]; then
+  yellow "   SessionStart hook already configured — skipping"
+else
+  jq --arg cmd "$SESSION_HOOK_CMD" '
+    .hooks = (.hooks // {}) |
+    .hooks.SessionStart = (.hooks.SessionStart // []) + [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": $cmd
+      }]
+    }]
+  ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
+  green "   SessionStart hook wired (injects _CLAUDE.md once per session)"
 fi
 
 # ── register slash commands ──────────────────────────────────────────────────


### PR DESCRIPTION
## What this PR does

Adds a SessionStart hook (`hooks/load_vault_context.py`) that injects `_CLAUDE.md` into
Claude's context automatically at session start when the cwd is inside `$OBSIDIAN_VAULT_PATH`.
Eliminates the per-command re-read of `_CLAUDE.md` that burned tokens on every invocation.
Updates `scripts/setup.sh` to wire the hook alongside the existing PostCompact agent.

Extracted from #19 as requested — hook + setup wiring only.

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update

## Related issues

Related to #19 (extracts the SessionStart hook portion; #19 to be closed in favour of focused PRs)

## How I tested it

- `bash scripts/setup.sh "/path/to/vault"` completes without error; `~/.claude/settings.json`
  gains a `SessionStart` entry pointing at the hook
- Hook fires on session start inside the vault: `_CLAUDE.md` content appears in context,
  no re-read needed on subsequent commands
- Hook skips silently when cwd is outside the vault path — non-vault sessions unaffected
- Path construction uses `Path(vault) / "..."` — correct separators on both Windows and POSIX

## AI-first rule compliance

N/A — this PR adds no vault-writing command.

## Checklist

- [x] Searched existing issues and PRs before opening this one
- [x] Commit messages are descriptive (focus on WHY, not just WHAT)
- [x] Updated `CHANGELOG.md` under "Unreleased"
- [x] Updated `SKILL.md` with Method 0 and the skip note for step 1
- [ ] README update — not applicable, no new user-facing command