### PR TITLE
Fix/setup eval metacharacters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Ensure shell scripts always use LF, regardless of editor/OS
+*.sh    text eol=lf
+*.bash  text eol=lf
+
+# Python
+*.py    text eol=lf
+
+# Default: normalize everything else to LF
+*       text=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **`scripts/setup.sh` robustness:** four issues fixed together. Vault paths containing apostrophes or other shell metacharacters (`Joe's Notes`) no longer crash the installer - `eval echo` replaced with bash parameter substitution. `python` replaced with `python3` for compatibility with macOS 13+ and Ubuntu 22+ which don't ship a `python` symlink. All three `settings.json` writes are now atomic (`mv` instead of `cat … && rm`). The MCP setup prompt is skipped when stdin is not a terminal so `curl | bash` installs and CI don't hang.
+
 - **`vault_stats.py` people count:** now counts both `type: person` and `type: entity` in the People aggregate. Real vaults using either convention report the correct count.
 - **Log layout routing in all commands:** every `/obsidian-*` command that reads or appends to the operation log now explicitly detects the vault layout (`Logs/YYYY-MM-DD.md` vs monolithic `log.md`) and uses the correct file and format. Previously, commands hardcoded `log.md` with the old `## [YYYY-MM-DD]` section-header format, which would write incorrectly formatted entries on modernized vaults.
 - **`vault_stats.py` folder exclusions case-insensitive:** `EXCLUDED_FOLDERS` comparison now uses `part.lower()`, so `templates/` and `Templates/` are both excluded. Added `raw/` to the exclusion set (immutable source folder convention).

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,7 +36,7 @@ if [[ -z "$VAULT" ]]; then
   exit 1
 fi
 
-VAULT="$(eval echo "$VAULT")"  # expand ~
+VAULT="${VAULT/#\~/$HOME}"  # expand leading ~
 
 if [[ ! -d "$VAULT" ]]; then
   red "Error: vault directory not found: $VAULT"
@@ -78,7 +78,7 @@ fi
 
 jq --arg vault "$VAULT" '
   .env = (.env // {}) | .env.OBSIDIAN_VAULT_PATH = $vault
-' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
+' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
 
 green "   OBSIDIAN_VAULT_PATH set"
 
@@ -117,13 +117,13 @@ else
         "async": true
       }]
     }]
-  ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
+  ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
   green "   PostCompact hook wired"
 fi
 
 # ── add SessionStart hook ────────────────────────────────────────────────────
 
-SESSION_HOOK_CMD="python $SESSION_HOOK"
+SESSION_HOOK_CMD="python3 $SESSION_HOOK"
 
 EXISTING_SESSION=$(jq -r '
   .hooks.SessionStart // [] |
@@ -143,7 +143,7 @@ else
         "command": $cmd
       }]
     }]
-  ' "$SETTINGS" > "$SETTINGS.tmp" && cat "$SETTINGS.tmp" > "$SETTINGS" && rm "$SETTINGS.tmp"
+  ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
   green "   SessionStart hook wired (injects _CLAUDE.md once per session)"
 fi
 
@@ -186,7 +186,10 @@ step "4. MCP server (optional — Claude Code only)..."
 echo "   The obsidian-vault MCP server gives Claude faster vault access."
 echo "   Without it, Claude reads/writes vault files directly (works fine)."
 echo ""
-read -r -p "   Configure MCP server for Claude Code? [y/N] " REPLY
+REPLY=n
+if [[ -t 0 ]]; then
+  read -r -p "   Configure MCP server for Claude Code? [y/N] " REPLY
+fi
 if [[ "$REPLY" =~ ^[Yy]$ ]]; then
   if command -v claude &>/dev/null; then
     claude mcp add obsidian-vault -s user -- npx -y mcp-obsidian "$VAULT"


### PR DESCRIPTION
## What this PR does

Fixes four robustness issues in `scripts/setup.sh` and a repo-wide CRLF line ending problem that caused all shell scripts to fail on Linux/macOS with `command not found` errors on the
carriage return character. Also adds `.gitattributes` to prevent recurrence.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

Closes #23

## How I tested it

- Ran `bash scripts/setup.sh --help` before and after — previously crashed on line 14 with `$'\r': command not found`; now prints usage cleanly.
- Manually verified that `bash scripts/setup.sh "~/Joe's Vault"` no longer crashes on the apostrophe.
- The `mv` atomicity, `python3`, and TTY guard changes are verifiable by inspection.

## AI-first rule compliance (required for any vault-writing command)

N/A — this PR only touches the installer script and repo config, not any vault-writing command.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [ ] I updated the README or docs if user-facing behavior changed
- [x] I updated `CHANGELOG.md` (under "Unreleased") if applicable
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table

## Screenshots / output (if visual or producing notes)

N/A