### PR TITLE
Promote "Verify Live State Before Acting" to _CLAUDE.md template

### DIFF
--- a/references/claude-md-template.md
+++ b/references/claude-md-template.md
@@ -48,6 +48,22 @@ This rule applies to all `/obsidian-*` and `/research*` commands, all scheduled 
 
 ---
 
+## Section 0.5 — Verify Live State Before Acting
+
+Before declaring a bug, drafting a fix, or writing architecture: read the actual code, schema, deployed branch, env, or live data. Speculation from stale context burns hours and produces drafts that contradict reality.
+
+Specific cues:
+- Read the schema or types before declaring a bug (real field names live in the code, not in memory)
+- `git fetch origin` and read the deployed branch, not local `main`
+- Grep the live file before any anchor-based patch
+- Fetch live time, dates, and rates (never infer from training data)
+- Verify env vars in the running process before blaming code
+- Mock tests miss schema drift: read one real payload before declaring "done"
+
+This is a general operating principle, not vault-specific. Keep it in `_CLAUDE.md` so every Claude session in this vault inherits it.
+
+---
+
 ## Vault Identity
 
 - **Owner:** [Full Name]


### PR DESCRIPTION
## Summary

- Adds Section 0.5 "Verify Live State Before Acting" to the canonical `references/claude-md-template.md`. Every new vault initialized via `/obsidian-init` from now on inherits the rule automatically.
- Sourced from a 30-day learnings review (2026-04-22 to 2026-05-22) that surfaced this exact pattern 10+ times across gateway, vault, brand, agent fleet, and FX work. By far the highest-frequency recurring lesson in that period.
- Generic version only — no Eugeniu-specific cues (`pm2 env`, etc.) leaked into the template. Personal vault adds the domain-specific version separately.

## Why

Mock tests miss schema drift. Speculation from stale context produces drafts that contradict reality. Reading the real code/schema/deployed branch/env before drafting is the cheapest insurance against 2+ hour wasted iterations. This pattern repeated enough across unrelated domains that it earned a permanent slot in the operating manual rather than living only as a learnings note.

## Impact

- **New vaults** initialized via `/obsidian-init` after this lands inherit the rule automatically.
- **Existing vaults** are unaffected. Users can add the section manually or re-run `/obsidian-init` to pull the updated template.
- Cross-platform: the dispatcher table in adapters will pick up the new section content via the existing template-read path. No adapter changes needed.

## Test plan

- [x] Inspected the rendered diff against the existing template structure (Section 0 ends, Section 0.5 inserted, Vault Identity follows). No structural breakage.
- [ ] On next `/obsidian-init` run against a fresh test vault, confirm the generated `_CLAUDE.md` contains the new section between Section 0 and Vault Identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)