### PR TITLE
Fix NotADirectoryError in check_empty_folders for vaults with root-level files

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -173,6 +173,8 @@ def check_empty_folders(vault: Path) -> list:
     for folder in vault.rglob("*/"):
         if any(p in EXCLUDE_DIRS for p in folder.parts):
             continue
+        if not folder.is_dir():
+            continue
         if not list(folder.iterdir()):
             rel = str(folder.relative_to(vault))
             issues.append({


### PR DESCRIPTION
## Summary

`vault_health.py:check_empty_folders` crashes with `NotADirectoryError` on any vault that has files at its root — including the `_CLAUDE.md` / `index.md` / `log.md` trio that `/obsidian-init` generates itself.

## Repro

```bash
python scripts/vault_health.py --path ~/path/to/vault --json
```

Observed on macOS APFS, vault containing `_CLAUDE.md`, `index.md`, `log.md` at root (standard `/obsidian-init` output):

```
Traceback (most recent call last):
  File ".../vault_health.py", line 321, in <module>
    main()
  File ".../vault_health.py", line 312, in main
    result = run_health_check(vault)
  File ".../vault_health.py", line 243, in run_health_check
    ("Empty folders", check_empty_folders(vault)),
  File ".../vault_health.py", line 176, in check_empty_folders
    if not list(folder.iterdir()):
NotADirectoryError: [Errno 20] Not a directory: '.../_CLAUDE.md'
```

## Root cause

`vault.rglob("*/")` returns entries that aren't always directories on some filesystems — the trailing slash is not a strict directory filter. `folder.iterdir()` then raises `NotADirectoryError` on the first non-directory entry, killing the whole health check.

## Fix

Single-line defensive guard:

```python
if not folder.is_dir():
    continue
```

inserted before `folder.iterdir()`. Matches the same pattern already used in `check_orphans` (line 208 of the same file).

## Test plan

- [x] Reproduce the crash on a vault containing `_CLAUDE.md`/`index.md`/`log.md` at root → `NotADirectoryError`
- [x] Apply the patch → `vault_health.py` runs to completion, emits valid JSON
- [x] Other checks (`check_broken_links`, `check_orphans`, frontmatter checks) unaffected
- [x] No new dependencies, no behavior change for vaults that previously worked

🤖 Generated with [Claude Code](https://claude.com/claude-code)