### PR TITLE
Fix vault_health: case-insensitive templates folder skip

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -220,7 +220,10 @@ def check_broken_links(notes: dict, vault: Path) -> list:
 def check_template_leftovers(notes: dict) -> list:
     issues = []
     for rel, note in notes.items():
-        if "Templates/" in rel:
+        # Skip files in any templates folder regardless of case.
+        # Vault conventions vary: Templates/, templates/, etc.
+        parts = rel.split("/")
+        if any(p.lower() == "templates" for p in parts):
             continue
         if TEMPLATE_RE.search(note["content"]):
             issues.append({


### PR DESCRIPTION
## Summary

`check_template_leftovers` previously hardcoded `Templates/` (capitalized only). Vaults using `templates/` (lowercase) or any other casing variant had every template file flagged as having "unfilled template syntax" — which is wrong, because templates SHOULD have unfilled syntax.

## Repro

Surfaced via `/obsidian-health` on Eugeniu's own vault on 2026-05-24:

- 723 notes scanned, 1247 total issues
- 19 of those were `template_leftover` errors flagged as `critical`
- All 19 lived in `templates/` (lowercase)
- All 19 were genuine, intentional template files with intentional Templater syntax

## Fix

Split the relative path into parts, check each one for case-insensitive equality with `"templates"`. Skips any folder named templates regardless of casing or nesting depth.

```diff
-        if "Templates/" in rel:
+        parts = rel.split("/")
+        if any(p.lower() == "templates" for p in parts):
             continue
```

## Why this pattern

Same shape as Martin P's case-insensitive fix to `vault_stats.py` `EXCLUDED_FOLDERS` in PR #22. Consistent across the two scripts.

## Test plan

- [x] Reproduced on Eugeniu's vault (`templates/` lowercase) → 19 false-positive `template_leftover` errors before the fix, 0 after.
- [x] Existing `Templates/` (capitalized) vaults still work — `any(p.lower() == "templates")` catches both.
- [x] Other checks (`check_broken_links`, `check_orphans`, etc.) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)