### PR TITLE
Skip _CLAUDE.md from vault_health broken-link scan

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -194,8 +194,15 @@ def check_broken_links(notes: dict, vault: Path) -> list:
         for alias in note["aliases"]:
             all_aliases[alias.lower()] = rel
 
+    # Operating manuals contain example wikilinks like [[wikilinks]], [[Related Project]],
+    # [[Links]] as syntax demonstrations, not as real references. Skip them from the
+    # broken-link scan so they don't generate dozens of false positives per scan.
+    SKIP_FROM_LINK_SCAN = {"_CLAUDE.md"}
+
     issues = []
     for rel, note in notes.items():
+        if Path(rel).name in SKIP_FROM_LINK_SCAN:
+            continue
         for link in note["links"]:
             link_stem = Path(link).stem.lower() if "/" in link else link.lower()
             link_norm = link_stem.replace("-", " ").replace("_", " ")


### PR DESCRIPTION
## Summary

`_CLAUDE.md` documents the vault's wikilink syntax for future-Claude readers. Its body contains example wikilinks like `[[wikilinks]]`, `[[Related Project]]`, `[[Links]]` purely as syntax demonstrations. They are not real references and should never resolve to a vault note.

The broken-link check currently flags all of them. On Eugeniu's vault that's ~190 false-positive broken-link warnings, all originating from the operating manual. Same noise hits every vault that uses the standard `_CLAUDE.md` generated by `/obsidian-init`.

## Fix

Add a `SKIP_FROM_LINK_SCAN` set at the top of `check_broken_links`. Skip files whose name is in the set.

```diff
+    # Operating manuals contain example wikilinks like [[wikilinks]], [[Related Project]],
+    # [[Links]] as syntax demonstrations, not as real references. Skip them from the
+    # broken-link scan so they don't generate dozens of false positives per scan.
+    SKIP_FROM_LINK_SCAN = {"_CLAUDE.md"}
+
     issues = []
     for rel, note in notes.items():
+        if Path(rel).name in SKIP_FROM_LINK_SCAN:
+            continue
         for link in note["links"]:
```

## Test plan

- [x] On Eugeniu's vault: 905 broken links before this PR, ~715 after (closes ~190 false positives).
- [x] Real broken links elsewhere in the vault still flagged correctly.
- [x] Vaults without `_CLAUDE.md` unaffected (set membership is a no-op).
- [x] Other checks (`check_orphans`, `check_duplicates`, etc.) unaffected.

## Why a set, not a hardcoded string

So we can add other operating manuals later (e.g. `SKILL.md` if a user copies it into the vault root, or `MEMORY.md` from project memory) without re-restructuring the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)