### PR TITLE
Normalize em-dashes in vault_health broken-link matching

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -186,8 +186,24 @@ def check_empty_folders(vault: Path) -> list:
     return issues
 
 
+def _normalize_dashes(s: str) -> str:
+    """Convert em-dash (U+2014) and en-dash (U+2013) to a regular hyphen.
+
+    Vault naming conventions often use em-dashes in filenames (e.g.
+    `2026-05-22 — Learnings Review.md`). Wikilinks that reference the same
+    note with a regular hyphen (`[[2026-05-22 - Learnings Review]]`) should
+    still resolve. Normalize both sides before comparison.
+    """
+    return s.replace("—", "-").replace("–", "-")
+
+
 def check_broken_links(notes: dict, vault: Path) -> list:
     all_stems = {note["stem"].lower(): rel for rel, note in notes.items()}
+    # also index stems with em-dashes normalized to regular hyphens so a
+    # wikilink written with `-` still matches a filename written with `—`
+    all_stems_dash_norm = {
+        _normalize_dashes(note["stem"]).lower(): rel for rel, note in notes.items()
+    }
     # build alias → rel lookup so [[Full Name]] resolves if the note has that alias
     all_aliases: dict[str, str] = {}
     for rel, note in notes.items():
@@ -206,11 +222,13 @@ def check_broken_links(notes: dict, vault: Path) -> list:
         for link in note["links"]:
             link_stem = Path(link).stem.lower() if "/" in link else link.lower()
             link_norm = link_stem.replace("-", " ").replace("_", " ")
+            link_dash_norm = _normalize_dashes(link_stem)
             resolved = (
                 link_stem in all_stems
                 or link_norm in all_stems
                 or link_stem in all_aliases
                 or link_norm in all_aliases
+                or link_dash_norm in all_stems_dash_norm
             )
             if not resolved:
                 potential_folder = vault / link


### PR DESCRIPTION
## Summary

Vault naming conventions often use em-dashes in filenames (e.g. `2026-05-22 — Learnings Review.md`, `wiki/logs/2026-04-26 — Description.md`). Wikilinks that reference the same note with a regular hyphen (`[[2026-05-22 - Learnings Review]]`) currently fail to resolve and get flagged as broken links, even though they are semantically correct.

## Fix

Add a `_normalize_dashes` helper that maps em-dash (U+2014) and en-dash (U+2013) to a regular hyphen. Build a second stem index with the normalized form. Add a fallback match path in `check_broken_links` that resolves links via the normalized lookup.

```python
def _normalize_dashes(s: str) -> str:
    return s.replace("—", "-").replace("–", "-")

# inside check_broken_links:
all_stems_dash_norm = {
    _normalize_dashes(note["stem"]).lower(): rel for rel, note in notes.items()
}
# ...
link_dash_norm = _normalize_dashes(link_stem)
resolved = (
    link_stem in all_stems
    or link_norm in all_stems
    or link_stem in all_aliases
    or link_norm in all_aliases
    or link_dash_norm in all_stems_dash_norm   # NEW
)
```

## Honest impact numbers

Surfaced via `/obsidian-health` on Eugeniu's vault 2026-05-24. On that vault the fix closes 17 broken-link false positives. Smaller impact than my initial estimate (~150-200) — the em-dash mismatches were less common than predicted. The bug is real and the fix is correct, just lower-impact.

Benefits every vault that uses em-dashes in filenames (which is the convention the skill's own `/obsidian-init` uses for dated logs and reviews).

## Test plan

- [x] Local run on Eugeniu's vault: 1030 → 1013 total issues (-17). All real broken links still flagged.
- [x] Vaults with no em-dashes in filenames unaffected (new normalized index is a superset of the existing one).
- [x] Other checks (`check_orphans`, `check_duplicates`, etc.) unaffected.
- [x] Composes cleanly with PR #30 (operating-manual skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)