### PR TITLE
Add centrality ranking and suggested-questions sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- **Centrality ranking in `/obsidian-visualize`:** the text summary now surfaces hub nodes (degree at least 3x the median or top 1% of the vault), bridge nodes ranked by approximate betweenness, stale-orphan flagging (>30 days old), silo clusters (<3 cross-cluster edges), and a centrality-skew warning when one node holds >25% of total edges. Turns the canvas into a structural diagnostic of the vault, not just a picture.
+- **Suggested questions for future-Claude in `/obsidian-recap` and `/obsidian-review`:** both commands now end with 4 to 5 questions the period's vault content is uniquely positioned to answer that the user has not asked yet. Each question cites at least one specific note via `[[wikilink]]`. Prefers questions that surface contradictions, connect co-appearing-but-unlinked entities, or name unstated next actions. Turns passive recaps into actionable prompts.
 - **SessionStart hook (`hooks/load_vault_context.py`):** injects `_CLAUDE.md` into context once per session when the session starts inside the vault. Eliminates the per-command re-read of `_CLAUDE.md` that burned tokens on every invocation. Wired automatically by `scripts/setup.sh`.
 - **`scripts/setup.sh` updated:** wires the new SessionStart hook (`hooks/load_vault_context.py`) in addition to the existing PostCompact background agent.
 - **Per-day operation logs:** `/obsidian-init` now creates a `Logs/` folder with per-day files (`Logs/YYYY-MM-DD.md`) instead of a monolithic `log.md`. Root `log.md` becomes a pointer file only. Cheaper to read, faster to query.

--- a/commands/obsidian-recap.md
+++ b/commands/obsidian-recap.md
@@ -15,6 +15,11 @@ The argument is the period: `today`, `week`, or `month`. Default to `week` if no
 5. Also spawn parallel agents to read dev logs and completed kanban tasks from the same period
 6. Synthesize all agent results: what was worked on, decisions made, people interacted with, tasks completed, ideas captured
 7. Present as a clean narrative summary — not a raw dump of note content
+8. End the recap with a **Suggested questions for future-Claude** section: 4 to 5 questions this period's vault content is uniquely positioned to answer that the user has not asked yet. Each question must cite at least one specific note (with `[[wikilink]]`) so future-Claude can resolve it without re-scanning. Prefer questions that:
+   - Surface tensions across notes (e.g., "Why does the X decision in [[note A]] contradict the rationale in [[note B]]?")
+   - Connect entities that co-appeared but were never explicitly linked
+   - Identify unstated next actions implied by the period's work
+   Avoid generic prompts ("What did I work on?") — the recap already answers those.
 
 ---
 

--- a/commands/obsidian-review.md
+++ b/commands/obsidian-review.md
@@ -19,6 +19,7 @@ The optional argument specifies `weekly` or `monthly`. Ask if not clear from con
    - People I worked with
    - What I learned
    - What to carry forward
+   - **Suggested questions for future-Claude** — 4 to 5 questions this period's vault content can answer that the user has not asked yet. Each question must cite at least one specific note (with `[[wikilink]]`). Prefer questions that surface contradictions across notes, connect entities that co-appeared without being explicitly linked, or name an unstated next action. Skip generic prompts the review section already covers.
 7. Save to `Reviews/YYYY-MM-DD — Weekly Review.md` (or Monthly)
 8. Link from the last daily note of the period
 

--- a/commands/obsidian-visualize.md
+++ b/commands/obsidian-visualize.md
@@ -39,12 +39,13 @@ The optional argument is a scope: a project name, entity name, topic, or "full" 
 
 5. Save to vault root as `atlas.canvas` (or `atlas-{topic}.canvas` if scoped)
 
-6. Also generate a text summary:
+6. Also generate a text summary with centrality ranking:
    - Total nodes and edges
-   - Top 5 hub nodes (most connected)
-   - Orphan nodes (no connections)
-   - Clusters found (groups of tightly connected notes)
-   - Bridge nodes (connect two otherwise separate clusters)
+   - **Hub nodes (centrality)** — top 5 by degree centrality, with the raw link count and a one-line "everything flows through this because…" note. A hub qualifies if its degree is at least 3x the median, or it sits in the top 1% of the vault — whichever surfaces fewer.
+   - **Bridge nodes** — nodes that, if removed, would split a cluster. Rank by betweenness (approximate: count the shortest paths each node sits on between the top-10 hubs). These are the load-bearing connectors; surface the top 3 with the two clusters each one joins.
+   - **Orphan nodes** — no connections, listed by type. Flag any that are >30 days old (stale orphans are higher-priority cleanup targets than fresh ones).
+   - **Clusters** — groups of tightly connected notes, named by their hub. Note any cluster with <3 cross-cluster edges (those are silos).
+   - **Centrality skew** — if one node holds >25% of total edges, call it out as a single point of failure for navigation.
 
 7. Append to the operation log: if `Logs/` exists write `**HH:MM** - visualize | Canvas generated - X nodes, Y edges, Z orphans` to `Logs/YYYY-MM-DD.md`; otherwise append `## [YYYY-MM-DD] visualize | Canvas generated — X nodes, Y edges, Z orphans` to `log.md`
 


### PR DESCRIPTION
## Summary

Two additions to surface structure and prompt better follow-up questions across the vault:

- **`/obsidian-visualize`** — text summary now surfaces hub nodes by degree centrality (threshold = 3x median or top 1%), bridge nodes ranked by approximate betweenness across the top-10 hubs, stale-orphan flagging (>30 days old), silo clusters (<3 cross-cluster edges), and a centrality-skew warning when one node holds >25% of total edges. Turns the canvas into a structural diagnostic, not just a picture.
- **`/obsidian-recap` and `/obsidian-review`** — both end with a "Suggested questions for future-Claude" section: 4-5 questions the period's vault content is uniquely positioned to answer that the user has not asked yet. Each question cites at least one specific note via `[[wikilink]]`. Prefers questions that surface contradictions, connect co-appearing-but-unlinked entities, or name unstated next actions.

## Test plan

- [x] Run `/obsidian-visualize` against a real vault and confirm hub-node + bridge output appears alongside the existing canvas
- [x] Run `/obsidian-recap week` and confirm the suggested-questions section appears at the end with wikilink citations
- [ ] Run `/obsidian-review weekly` and confirm the suggested-questions bullet is included in the saved review note
- [ ] Verify no AI-first rule regressions (preamble, frontmatter, wikilinks still required by the section headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)