### PR TITLE
fix(research): platform-aware auto-open for Windows and Linux

### DIFF
--- a/scripts/research/lib/vault.py
+++ b/scripts/research/lib/vault.py
@@ -113,7 +113,15 @@ def print_save_links(note_path: Path, file=None) -> None:
     # Auto-open in Obsidian by default. Disable with RESEARCH_AUTOOPEN=0.
     if os.environ.get("RESEARCH_AUTOOPEN", "1") != "0":
         try:
-            subprocess.run(["open", uri], check=False, timeout=5)
+            import platform
+            # Platform-aware open: `open` on macOS, `xdg-open` on Linux,
+            # `cmd /c start "" <uri>` on Windows (the empty "" is the window title).
+            open_cmd = {
+                "Darwin": ["open", uri],
+                "Linux": ["xdg-open", uri],
+                "Windows": ["cmd", "/c", "start", "", uri],
+            }.get(platform.system(), ["open", uri])
+            subprocess.run(open_cmd, check=False, timeout=5)
         except Exception:
             pass  # auto-open is a nice-to-have, never block the save flow
 


### PR DESCRIPTION
## Problem

`print_save_links()` auto-opens the saved research note in Obsidian via:

```python
subprocess.run(["open", uri], check=False, timeout=5)
```

This is hard-coded to macOS. On Windows there is no `open` executable, on Linux there isn't either by default (`xdg-open` is the convention). The call fails silently (it's wrapped in `try/except: pass`), so saves still work — auto-open just never fires.

`CONTRIBUTING.md` already lists this exact area as ripe for a PR:

> The skill currently assumes macOS (`install.sh`, `~/.config` paths, the `open` command for auto-opening notes in Obsidian). Linux/Windows support PRs are welcome.

This is the `open` command part.

## Fix

Pick the right opener per `platform.system()`. The `obsidian://open?...` URI itself is unchanged — Obsidian registers its protocol handler on all three OS, so the URI works everywhere once the platform-appropriate launcher fires.

```python
open_cmd = {
    "Darwin":  ["open", uri],
    "Linux":   ["xdg-open", uri],
    "Windows": ["cmd", "/c", "start", "", uri],
}.get(platform.system(), ["open", uri])
subprocess.run(open_cmd, check=False, timeout=5)
```

The empty `""` after `start` is the Windows shell window title — required because `start` treats the first quoted arg as the title, not the target.

Fallback to `["open", uri]` for unknown platforms preserves current behavior — no regression for any environment that worked before.

## Scope

- 1 file changed: `scripts/research/lib/vault.py`
- +9 / -1 lines
- No new dependencies (`platform` is stdlib)
- No behavior change on macOS
- No test framework exists in this repo, so this is verified by inspection + local manual run on Windows 11 (Git Bash). On macOS this is unchanged. Linux path is identical to standard `xdg-open` usage.

## Out of scope (separate concerns)

- `install.sh` rewrite for Windows/Linux — bigger task, separate PR
- `~/.config` paths — already work via Git Bash on Windows; only docs language ("Mac-local") slightly misleading

## Notes for the maintainer

Spotted while doing a Windows-compatibility audit of the skill for a Russian-language vault on Windows 11. The vault works great — this was the only behavioral gap that affects users without breaking workflows. The `try/except: pass` wrapper meant nobody noticed silently for a while, but the auto-open UX really is missed on non-macOS.

Happy to split, rebase, or rework if you'd prefer a different shape.
