### PR TITLE
fix(install): platform-aware editor and uv-install hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install.sh` cross-platform editor and uv-install hint:** the `${EDITOR:-open}` fallback was macOS-only — on Linux it threw `open: command not found`, on Windows (Git Bash) likewise. Now picks `xdg-open` on Linux, `notepad` on Windows (MSYS/MINGW/Cygwin), `open` on macOS. The "uv not found" hint also branches per platform: `brew install uv` on macOS, `curl … | sh` on Linux, the PowerShell one-liner on Windows. Matches the same pattern PR #34 applied to `scripts/research/lib/vault.py`.
+
 ### Added
 
 - **Centrality ranking in `/obsidian-visualize`:** the text summary now surfaces hub nodes (degree at least 3x the median or top 1% of the vault), bridge nodes ranked by approximate betweenness, stale-orphan flagging (>30 days old), silo clusters (<3 cross-cluster edges), and a centrality-skew warning when one node holds >25% of total edges. Turns the canvas into a structural diagnostic of the vault, not just a picture.

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,13 @@ setup_research=${setup_research:-N}
 if [[ "$setup_research" =~ ^[Yy]$ ]]; then
   # Verify uv is available
   if ! command -v uv >/dev/null 2>&1; then
-    echo "  ⚠️  'uv' not found. Install with: brew install uv"
+    case "$(uname -s)" in
+      Darwin)               uv_hint="brew install uv" ;;
+      Linux)                uv_hint="curl -LsSf https://astral.sh/uv/install.sh | sh" ;;
+      MINGW*|MSYS*|CYGWIN*) uv_hint="powershell -c \"irm https://astral.sh/uv/install.ps1 | iex\"" ;;
+      *)                    uv_hint="see https://docs.astral.sh/uv/getting-started/installation/" ;;
+    esac
+    echo "  ⚠️  'uv' not found. Install with: $uv_hint"
     echo "     Then re-run this installer to finish research toolkit setup."
   else
     echo "  Installing Python deps via uv..."
@@ -73,7 +79,13 @@ if [[ "$setup_research" =~ ^[Yy]$ ]]; then
   echo "    YOUTUBE_API_KEY=      (https://console.cloud.google.com — optional)"
   echo ""
   read -r -p "  Press Enter to open the file in your default editor (or Ctrl+C to skip)... " _
-  ${EDITOR:-open} "$ENV_FILE"
+  # Pick a default opener if $EDITOR is unset. Original used `open` (macOS-only).
+  default_editor=open
+  case "$(uname -s)" in
+    Linux)                default_editor=xdg-open ;;
+    MINGW*|MSYS*|CYGWIN*) default_editor=notepad ;;
+  esac
+  ${EDITOR:-$default_editor} "$ENV_FILE"
 fi
 
 echo ""


### PR DESCRIPTION
## Problem

`install.sh:76` falls back to `open` when `\$EDITOR` is unset:

\`\`\`bash
\${EDITOR:-open} "\$ENV_FILE"
\`\`\`

That's macOS-only. On Linux it errors with `open: command not found`. On Windows (Git Bash / MSYS) likewise.

The "uv not found" message at `install.sh:51` also hard-codes the macOS install path (`brew install uv`).

`CONTRIBUTING.md` lists `install.sh` as ripe for cross-platform PRs.

## Fix

Same pattern PR #34 used for `scripts/research/lib/vault.py` — branch per `uname -s`:

- **Editor fallback**: `open` on Darwin, `xdg-open` on Linux, `notepad` on Windows (MSYS/MINGW/Cygwin)
- **uv install hint**: `brew install uv` on Darwin, `curl -LsSf https://astral.sh/uv/install.sh | sh` on Linux, the PowerShell `irm` one-liner on Windows, generic docs link otherwise

## Scope

- 1 file changed: `install.sh` (+17 lines, -2 lines including a CHANGELOG entry)
- `bash -n install.sh` passes (syntax-checked)
- No behavior change on macOS — `\$(uname -s)` returns `Darwin`, keeps existing `open` and `brew install uv` paths
- No new dependencies

## Out of scope

- A native `install.ps1` for users without Git Bash — bigger task, separate PR if anyone needs it. The current `install.sh` runs fine under Git Bash / WSL on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)