### PR TITLE
Refresh command count across docs (32/33 -> 34)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software in research or write about it, please cite as below."
 title: "obsidian-second-brain"
 abstract: >
-  A 33-command cross-CLI skill that turns any Obsidian vault into a living
+  A 34-command cross-CLI skill that turns any Obsidian vault into a living
   AI-first second brain. Runs in Claude Code, OpenAI Codex CLI, Google
   Gemini CLI, and OpenCode from one platform-neutral source via a
   build-time adapter pattern. Includes vault management, thinking tools,

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,7 +109,7 @@ See `references/vault-schema.md` for full structural details.
 ## Core Operating Principles
 
 ### AI-first vault rule (applies to every note)
-The vault is designed for **future-Claude** to read and reason over, not for human review. Every note Claude writes — across all 32 commands — must follow `references/ai-first-rules.md`:
+The vault is designed for **future-Claude** to read and reason over, not for human review. Every note Claude writes — across all 34 commands — must follow `references/ai-first-rules.md`:
 
 1. **Self-contained context** — each note explains itself; don't rely on backlinks alone
 2. **"For future Claude" preamble** — 2-3 sentence summary so Claude can decide relevance in 10 seconds

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,12 @@
 title: obsidian-second-brain
 description: >-
-  A 32-command cross-CLI skill that turns any Obsidian vault into a living
+  A 34-command cross-CLI skill that turns any Obsidian vault into a living
   AI-first second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini
   CLI, and OpenCode from one platform-neutral source. Vault management,
   thinking tools, scheduled agents, a research toolkit (live X, web,
-  YouTube), a write-time AI-first validator hook, and an interview-driven
-  /create-command flow for user-built extensions.
+  YouTube, podcasts, vault-grounded synthesis via Gemini), a write-time
+  AI-first validator hook, and an interview-driven /create-command flow
+  for user-built extensions.
 theme: jekyll-theme-cayman
 plugins:
   - jekyll-seo-tag

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,12 @@
 # obsidian-second-brain
 
-> A cross-CLI skill that turns any Obsidian vault into a self-rewriting second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini CLI, and OpenCode from one platform-neutral source via a build-time adapter pattern. An evolution of Karpathy's LLM Wiki pattern (https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): every source updates existing pages instead of just appending, contradictions reconcile automatically, and 4 scheduled agents maintain the vault while you sleep. 32 commands span vault management, thinking tools, scheduled agents, and a research toolkit (live X posts via Grok, web research via Perplexity, YouTube transcripts), plus a write-time AI-first validator hook and a `/create-command` interview flow for user-built extensions.
+> A cross-CLI skill that turns any Obsidian vault into a self-rewriting second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini CLI, and OpenCode from one platform-neutral source via a build-time adapter pattern. An evolution of Karpathy's LLM Wiki pattern (https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): every source updates existing pages instead of just appending, contradictions reconcile automatically, and 4 scheduled agents maintain the vault while you sleep. 34 commands span vault management, thinking tools, scheduled agents, and a research toolkit (live X posts via Grok, web research via Perplexity, YouTube transcripts, podcast episodes via RSS or Whisper, and vault-grounded synthesis via Gemini File Search), plus a write-time AI-first validator hook and a `/create-command` interview flow for user-built extensions.
 
 ## What this is
 
 obsidian-second-brain is an open-source skill (MIT license) for Obsidian users who use an AI CLI as their primary interface to their own knowledge. It treats the vault as a knowledge base optimized for AI retrieval rather than human reading. Every note follows an AI-first design rule: self-contained context, "For future Claude" preamble, rich machine-readable frontmatter, recency markers per claim, sources preserved verbatim, mandatory wikilinks, and confidence levels.
 
-The skill is platform-neutral. The same 32 commands run in Claude Code (slash commands + `CLAUDE.md`), OpenAI Codex CLI (`AGENTS.md` + `.codex/commands/`), Google Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). One codebase compiles into all four via `bash scripts/build.sh`.
+The skill is platform-neutral. The same 34 commands run in Claude Code (slash commands + `CLAUDE.md`), OpenAI Codex CLI (`AGENTS.md` + `.codex/commands/`), Google Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). One codebase compiles into all four via `bash scripts/build.sh`.
 
 Owner: Eugeniu Ghelbur. AI Automation Engineer at Single Grain.
 
@@ -39,7 +39,7 @@ The complete analysis of how this skill extends Karpathy's pattern, including th
 
 - "I rebuilt Karpathy's LLM Wiki. Here's what's missing from the original." (2026-04-29). https://theaioperator.io/p/i-rebuilt-karpathys-llm-wiki-heres
 
-## The 32 commands (organized by category)
+## The 34 commands (organized by category)
 
 **Vault (11)** — daily writing, capture, find, kanban, recall:
 obsidian-board, obsidian-capture, obsidian-daily, obsidian-find, obsidian-log, obsidian-person, obsidian-project, obsidian-recap, obsidian-save, obsidian-task, obsidian-world.
@@ -47,8 +47,8 @@ obsidian-board, obsidian-capture, obsidian-daily, obsidian-find, obsidian-log, o
 **Thinking (10)** — synthesis, decisions, learning, reviews:
 obsidian-adr, obsidian-challenge, obsidian-connect, obsidian-decide, obsidian-emerge, obsidian-graduate, obsidian-learn, obsidian-reconcile, obsidian-review, obsidian-synthesize.
 
-**Research (6)** — bring external sources into the vault:
-obsidian-ingest, research, research-deep, x-pulse, x-read, youtube. Powered by xAI Grok (X + Live Search), Perplexity Sonar (web with citations), and youtube-transcript-api.
+**Research (8)** — bring external sources into the vault:
+obsidian-ingest, notebooklm, podcast, research, research-deep, x-pulse, x-read, youtube. Powered by xAI Grok (X + Live Search), Perplexity Sonar (web with citations), Google Gemini File Search (vault-grounded synthesis), youtube-transcript-api, and feedparser + optional OpenAI Whisper for podcasts.
 
 **Meta (5)** — vault setup, health, structure, tooling:
 obsidian-export, obsidian-health, obsidian-init, obsidian-visualize, create-command.


### PR DESCRIPTION
Drive-by cleanup after PR #7 landed /podcast — several doc surfaces still referenced older command counts.

## Updated

- **CITATION.cff** — `A 33-command...` -> `A 34-command...`
- **SKILL.md** — `across all 32 commands` -> `across all 34 commands`
- **_config.yml** (Jekyll docs site) — `A 32-command...` -> `A 34-command...`, plus expanded research-toolkit description to include podcasts and vault-grounded Gemini synthesis.
- **llms.txt** (AI-crawler spec) — `32 commands` -> `34 commands` in 3 places. Research category bumped from `(6)` to `(8)` with `notebooklm` and `podcast` added to the listed commands, plus the power-source blurb updated to mention Gemini File Search and `feedparser` + Whisper.

## Also done outside this PR

- **GitHub About description** patched via API from "32 commands" to "34 commands"

## Not done — needs human

- **`media/banner.png`** still has "33 commands" rendered as image text. Needs to be regenerated via `gic`. Suggested prompt left in the chat.

## Scope

4 files changed, +11/-10 lines. No code, no behavior change, just doc count refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)