### PR TITLE
Add missing category: and triggers_en: to /podcast command

### DIFF
--- a/commands/podcast.md
+++ b/commands/podcast.md
@@ -1,5 +1,7 @@
 ---
 description: Extract metadata, transcript, and summary from a podcast episode, saved as an AI-first note in the vault
+category: research
+triggers_en: ["summarize this podcast", "podcast episode summary", "extract podcast", "what's in this episode"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/podcast [url]`:


### PR DESCRIPTION
## Summary

PR #7 (Connor's `/podcast` command) shipped without `category:` or `triggers_en:` in its frontmatter. Every other command in `commands/` declares both. The adapter scripts use these fields when emitting dispatcher files for non-Claude platforms (Codex CLI, Gemini CLI, OpenCode).

Without `category:`, `/podcast` was appearing in an uncategorized leftover slot in the routing tables. Without `triggers_en:`, natural-language phrases like "summarize this podcast" did not map to the command on those platforms.

Claude Code (primary platform) was unaffected since it doesn't use either field.

## Change

```diff
 ---
 description: Extract metadata, transcript, and summary from a podcast episode, saved as an AI-first note in the vault
+category: research
+triggers_en: ["summarize this podcast", "podcast episode summary", "extract podcast", "what's in this episode"]
 ---
```

## Final category count

After this change: **11 vault + 10 thinking + 8 research + 5 meta = 34**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)