### PR TITLE
Document per-project vault setup for multi-repo workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Documentation
+
+- **Per-project vault setup documented** (closes question in Discussion #11): added a "Per-Project Vaults (multi-repo workflows)" section to `SKILL.md` and a matching FAQ entry in `README.md`. Recipe: drop `{"env": {"OBSIDIAN_VAULT_PATH": "..."}}` into each repo's `.claude/settings.json`; Claude Code's per-project settings merge over the global one and every hook reads `OBSIDIAN_VAULT_PATH` from env at fire-time, so each project session routes to its own vault. The pattern always worked; nobody had written down the recipe.
+
 ### Fixed
 
 - **`bootstrap_vault.py` templates now AI-first compliant (#16):** all 17 templates emitted by the bootstrapper (`Daily Note`, `Project`, `Person`, `Task`, `Dev Log`, `Goal`, `Mention`, `Meeting`, `Decision`, `OKR`, `Architecture`, `Debug`, `Post`, `Audience Note`, `Source`, `Literature Note`, `Hypothesis`) now include `type:` and `ai-first: true` in frontmatter plus a `## For future Claude` preamble in the body. Notes created from these templates now pass `hooks/validate-ai-first.sh` cleanly. Previously every Write/Edit on a templated note warned, undermining the AI-first rule the skill is built around. `Templates/Source.md` renamed its existing `type:` field to `source_kind:` to free up `type:` for the ai-first frontmatter (the field was for book/paper/podcast/video, never the note's ai-first type). Added a `references/ai-first-rules.md` reference block to the top of `bootstrap_vault.py` so future contributors see the rule.

--- a/README.md
+++ b/README.md
@@ -656,6 +656,9 @@ Approximate per-call costs as of 2026-04: `/x-read` ~$0.05, `/x-pulse` ~$0.13, `
 ### Can I use this on Windows or Linux?
 The core vault commands work anywhere Claude Code runs. The research toolkit was tested on macOS — `install.sh` and the auto-open behavior assume macOS conventions (`~/.config`, `open` command). Pull requests welcome to add Windows and Linux paths.
 
+### Can I have a separate vault per project (multi-repo workflows)?
+Yes. The default `scripts/setup.sh` writes `OBSIDIAN_VAULT_PATH` globally to `~/.claude/settings.json`, but every hook in this skill reads that env var at fire-time. Claude Code merges per-project `.claude/settings.json` on top of the global one, so you can put `{"env": {"OBSIDIAN_VAULT_PATH": "/path/to/repo-vault"}}` in each repo's `.claude/settings.json` and Claude will use that repo's vault whenever you launch a session from that directory. The slash commands and hooks remain globally installed; only the vault path changes. Full recipe in [`SKILL.md`](SKILL.md#per-project-vaults-multi-repo-workflows). One thing this does NOT give you: isolation within a single vault (no `--scope` on commands yet).
+
 ### How do I update to the latest version?
 ```bash
 cd ~/.claude/skills/obsidian-second-brain && git pull

--- a/SKILL.md
+++ b/SKILL.md
@@ -1172,6 +1172,34 @@ A non-blocking validator that fires after every `Write` or `Edit` on a markdown 
 
 ---
 
+## Per-Project Vaults (multi-repo workflows)
+
+The default install path (`scripts/setup.sh`) writes `OBSIDIAN_VAULT_PATH` into `~/.claude/settings.json` (global). That assumes one machine = one vault. If you work across multiple repos and want each to have its own dedicated vault — or want to keep work and personal vaults separate without manually swapping config — use Claude Code's per-project settings to override the global setting on a per-directory basis.
+
+**How it works:** every hook in this skill (`hooks/load_vault_context.py`, `hooks/validate-ai-first.sh`, `hooks/obsidian-bg-agent.sh`) reads `OBSIDIAN_VAULT_PATH` from process env at fire-time. Claude Code merges `.claude/settings.json` from the current project directory on top of `~/.claude/settings.json`, so a project-scoped env block overrides the global one for any session launched from that directory.
+
+**Setup per repo:**
+
+1. Bootstrap each vault once: `bash scripts/setup.sh` for the first vault (writes the global default), then `python scripts/bootstrap_vault.py --path ~/vaults/repo-b --name "Your Name"` for any additional vaults (skips the global config step).
+
+2. In each repo where you want a non-default vault, create `.claude/settings.json`:
+
+   ```json
+   {
+     "env": {
+       "OBSIDIAN_VAULT_PATH": "/Users/you/vaults/repo-a-vault"
+     }
+   }
+   ```
+
+3. Restart Claude Code (or open a new session in that directory). All slash commands, hooks, and scripts will now operate on the project-specific vault.
+
+**What this does NOT give you:** isolation within a single vault. The skill has no `--scope` concept — `/obsidian-find`, `/obsidian-recap`, and `/obsidian-emerge` scan the entire configured vault. If you want multiple projects sharing one vault, you can organize them by top-level folders for visual grouping, but commands will still see across folders. A real `--scope` refactor is tracked in discussion threads — open a discussion if this is your use case.
+
+**Slash commands and hooks are still globally installed.** Only the `OBSIDIAN_VAULT_PATH` env var is per-project. You do not need to re-symlink commands or re-register hooks per repo.
+
+---
+
 ## Reference Files
 
 - `references/vault-schema.md` — Complete folder structure + frontmatter specs for all note types


### PR DESCRIPTION
Closes the question in [Discussion #11](https://github.com/eugeniughelbur/obsidian-second-brain/discussions/11) (@francislee-cn, 2026-05-07).

## Why

@francislee-cn asked whether the skill supports either (a) per-project vaults or (b) multiple projects sharing one vault with folder isolation. His read of the code was that the skill assumes one machine = one vault, since `scripts/setup.sh` writes `OBSIDIAN_VAULT_PATH` to the global `~/.claude/settings.json`.

The pattern (a) was always supported — every hook in this skill (`hooks/load_vault_context.py`, `hooks/validate-ai-first.sh`, `hooks/obsidian-bg-agent.sh`) reads `OBSIDIAN_VAULT_PATH` from process env at fire-time, and Claude Code merges per-project `.claude/settings.json` on top of the global config. But nobody had written down the recipe, so the user reasonably concluded the skill did not support it.

## Change

- **SKILL.md**: new "Per-Project Vaults (multi-repo workflows)" section with the full recipe, what it does NOT enable (no in-vault scope isolation), and the bootstrap path for additional vaults.
- **README.md**: FAQ entry pointing at the SKILL.md section.
- **CHANGELOG.md**: Unreleased entry under a new Documentation subhead.

No code change.

## Test plan

- [x] Recipe verified by reading the three hook scripts — all read `OBSIDIAN_VAULT_PATH` from process env, no caching
- [x] Cross-reference links resolve (README → SKILL.md anchor)
- [ ] Manual: set up two vaults, drop per-repo `.claude/settings.json` in each, confirm hooks fire against the right vault in each session

🤖 Generated with [Claude Code](https://claude.com/claude-code)