### PR TITLE
Add non-ASCII substitution character check to validate-ai-first.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Non-ASCII substitution character check in `validate-ai-first.sh` (check 5):** the hook now detects banned Unicode that slips in silently via LLM defaults: em-dashes (`—`), en-dashes (`–`), curly/smart quotes, Unicode math substitutions (`≥ ≤ ≠`), ellipsis (`…`), and non-breaking spaces. Each violation reports the exact codepoint, line number, and a suggested ASCII replacement. Whitelist covers box-drawing chars (U+2500-257F), arrows (`→ ←`), currency symbols (`€ £ ¥`), private-use / Nerd Font codepoints, and emoji - all carry semantic meaning rather than substituting for ASCII. Specific em-dash ban was unenforceable in practice; the broader codepoint-level check catches the full substitution-Unicode class. Rule documented in `CLAUDE.md` conventions and `references/ai-first-rules.md` anti-patterns table.
+
 ### Documentation
 
 - **Per-project vault setup documented** (closes question in Discussion #11): added a "Per-Project Vaults (multi-repo workflows)" section to `SKILL.md` and a matching FAQ entry in `README.md`. Recipe: drop `{"env": {"OBSIDIAN_VAULT_PATH": "..."}}` into each repo's `.claude/settings.json`; Claude Code's per-project settings merge over the global one and every hook reads `OBSIDIAN_VAULT_PATH` from env at fire-time, so each project session routes to its own vault. The pattern always worked; nobody had written down the recipe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ If you are editing a command file in `commands/`, do not rewrite the AI-first pr
 
 ## Conventions
 
-- **Markdown:** sentence-case headers (`## What it does`, not `## What It Does`). No emojis in command files. No em-dashes (`—`) in user-facing prose — use a regular dash or restructure the sentence.
+- **Markdown:** sentence-case headers (`## What it does`, not `## What It Does`). No emojis in command files. No substitution Unicode in source files, docs, or commits: em-dashes (`—`), en-dashes (`–`), curly/smart quotes, and Unicode math substitutions (`≥ ≤ ≠`) are banned. Allowed: box-drawing chars (`─` U+2500-257F), arrows (`→ ←`), currency symbols (`€ £ ¥`), and Nerd Font / private-use codepoints - all carry semantic meaning rather than substituting for ASCII. Enforced by `hooks/validate-ai-first.sh` check 5 on vault writes.
 - **Python:** ruff with `line-length = 100`, target `py310`. Type hints encouraged, not required.
 - **Commits:** imperative mood (`Add`, `Fix`, `Update`). Co-author Claude when pair-programmed.
 - **Frontmatter:** YAML, double-quoted strings when in doubt, lowercase tag values.

--- a/hooks/validate-ai-first.sh
+++ b/hooks/validate-ai-first.sh
@@ -15,6 +15,10 @@
 #   2. No tabs inside frontmatter (YAML requires spaces)
 #   3. Required AI-first fields present: date, type, tags, ai-first: true
 #   4. `## For future Claude` preamble exists in the body
+#   5. No banned non-ASCII substitution characters (em/en-dashes, curly
+#      quotes, smart apostrophes, Unicode math/arrows). Reports codepoint +
+#      suggested ASCII replacement. Whitelist: box-drawing U+2500-257F,
+#      currency (EUR/GBP/JPY), private-use/Nerd Fonts, emoji.
 #
 # Scope:
 #   - Only inspects files inside OBSIDIAN_VAULT_PATH (env var)
@@ -97,6 +101,60 @@ fi
 BODY=$(awk '/^---$/{c++; if (c<2) next; next} c>=2' "$FILE")
 if ! printf '%s\n' "$BODY" | grep -qE '^##[[:space:]]+For future Claude' ; then
   WARNINGS+=("$BASENAME missing '## For future Claude' preamble (required by ai-first-rules.md rule #2).")
+fi
+
+# ── Check 5: non-ASCII substitution characters ───────────────────────────────
+if command -v python3 >/dev/null 2>&1; then
+  NON_ASCII_HITS=$(python3 - "$FILE" <<'PYEOF'
+import sys
+
+BANNED = {
+    '—': ('U+2014 em-dash',            ' - '),
+    '–': ('U+2013 en-dash',             ' - '),
+    '“': ('U+201C left double quote',   '"'),
+    '”': ('U+201D right double quote',  '"'),
+    '‘': ('U+2018 left single quote',   "'"),
+    '’': ('U+2019 right single quote',  "'"),
+    '≥': ('U+2265 >=',                  '>='),
+    '≤': ('U+2264 <=',                  '<='),
+    '≠': ('U+2260 !=',                  '!='),
+    '…': ('U+2026 ellipsis',            '...'),
+    ' ': ('U+00A0 non-breaking space',  ' '),
+}
+
+def allowed(cp):
+    if 0x2500 <= cp <= 0x257F: return True   # box-drawing chars
+    if cp in (0x20AC, 0x00A3, 0x00A5): return True  # EUR, GBP, JPY
+    if 0xE000 <= cp <= 0xF8FF: return True   # private use / Nerd Fonts
+    if 0x2600 <= cp <= 0x27BF: return True   # misc symbols + dingbats
+    if 0x1F300 <= cp <= 0x1FFFF: return True # emoji
+    return False
+
+path = sys.argv[1]
+seen = set()
+try:
+    with open(path, encoding='utf-8', errors='replace') as fh:
+        for lineno, line in enumerate(fh, 1):
+            for ch in line:
+                cp = ord(ch)
+                if cp <= 127 or allowed(cp) or ch not in BANNED:
+                    continue
+                key = (lineno, ch)
+                if key in seen:
+                    continue
+                seen.add(key)
+                name, suggest = BANNED[ch]
+                print(f"    line {lineno}: {name} -- try {suggest!r}")
+except OSError:
+    pass
+PYEOF
+  )
+  if [[ -n "$NON_ASCII_HITS" ]]; then
+    WARNINGS+=("$BASENAME contains banned non-ASCII substitution characters:")
+    while IFS= read -r hit; do
+      [[ -n "$hit" ]] && WARNINGS+=("$hit")
+    done <<< "$NON_ASCII_HITS"
+  fi
 fi
 
 # ── Emit warnings ────────────────────────────────────────────────────────────

--- a/references/ai-first-rules.md
+++ b/references/ai-first-rules.md
@@ -282,6 +282,7 @@ Don't do these. They produce notes that are useless to future-Claude.
 | Trusting the model to infer | Be explicit. State the type, the rule applied, the source. |
 | Multi-paragraph human-readable narratives | Bullets and structure beat prose for retrieval. |
 | Forgetting `ai-first: true` | The flag lets future-Claude know which notes meet the standard. |
+| Em-dash (`—`), curly quotes (`"`), Unicode math (`≥ ≤ ≠`) | Substitution Unicode slips in silently via LLM defaults. Caught by `validate-ai-first.sh` check 5. Use ` - ` for dashes, straight `"` quotes, ASCII operators (`>=`, `!=`). Allowed: box-drawing (`─`), arrows (`→ ←`), currency (`€ £ ¥`), Nerd Font codepoints - all carry semantic meaning. |
 
 ---
 


### PR DESCRIPTION
<!-- Thanks for contributing! A few quick checks make it more likely your PR ships fast. -->

## What this PR does

Adds check 5 to `hooks/validate-ai-first.sh`: detects banned non-ASCII substitution characters in vault notes and reports codepoint, line number, and suggested replacement. The specific em-dash ban in CLAUDE.md was not holding in practice - this replaces it with mechanical enforcement.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

Related to discussion on non-ASCII ban and em-dash whitelist.

Closes #42

## How I tested it

Ran the Check 5 Python logic as a standalone dry-run against all tracked `.md`, `.py`, and `.sh` files in the repo. Result: 852 violations across 90 files, zero false positives from the whitelist (box-drawing, arrows, currency, emoji all passed through cleanly). This output also establishes the scope for the follow-up sweep PR.

## AI-first rule compliance (required for any vault-writing command)

- [x] My changes follow `references/ai-first-rules.md`
- [ ] If I added or changed a command that writes to the vault, the produced note has a `## For future Claude` preamble
- [ ] Frontmatter includes `ai-first: true`, `type:`, `date:`, `tags:`
- [ ] Wikilinks (`[[...]]`) used for every person, project, idea, decision referenced
- [ ] External claims have recency markers (`(as of YYYY-MM, source.com)`)
- [ ] Sources preserved verbatim (URLs inline, not paraphrased)

N/a - this PR changes a hook, not a vault-writing command.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [x] I updated the README or docs if user-facing behavior changed
- [x] I updated `CHANGELOG.md` (under "Unreleased") if applicable
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table

N/a - no new command.

## Screenshots / output (if visual or producing notes)

Dry-run output (first file, representative sample):

```
CHANGELOG.md
  line 11: U+2014 em-dash -- try ' - '
  line 11: U+2013 en-dash -- try ' - '
  line 11: U+2265 >= -- try '>='
  ...

--- 852 violation(s) across 90 files scanned ---
```

Whitelist held: no false positives on box-drawing chars, arrows (-> <-), currency symbols, or emoji across all 90 files.

**Follow-up:** sweep PR will convert all 852 violations. That PR is intentionally separate so a bad substitution cannot block this rule from landing, and the sweep can be reverted independently if anything reads wrong.

---

<!-- Maintainers: thanks for reviewing! -->
