### PR TITLE
Add substitution-character CI gate (em-dash linter, #49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,8 @@ jobs:
         run: python -m pip install --upgrade pip pytest requests
       - name: Run smoke tests
         run: pytest -q
+      # Fail the build if a banned substitution character (em-dash, curly quote,
+      # Unicode math, ...) appears in prose in any tracked source file. Characters
+      # inside code fences / backtick spans are preserved and never fail.
+      - name: Lint substitution characters
+        run: python scripts/sweep_non_ascii.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **CI gate for substitution characters.** `scripts/sweep_non_ascii.py` gained a `--check` mode that exits non-zero when a banned substitution character (em-dash, en-dash, curly quotes, Unicode math, ellipsis, non-breaking space) appears in prose in any tracked `.md`/`.py`/`.sh` file. Characters inside code fences and inline backtick spans are preserved and never fail the check. Wired into `.github/workflows/ci.yml` so the rule is enforced on every push and PR (complements the write-time `validate-ai-first.sh` hook, which only covers vault notes). Two new smoke tests lock the behavior. (FORK_INSIGHTS.md #49; pattern from the johanvillalbab fork, generalized to the full banned-character set.)
+
 ## [0.9.0] - 2026-05-31
 
 ### Changed

--- a/scripts/sweep_non_ascii.py
+++ b/scripts/sweep_non_ascii.py
@@ -12,6 +12,12 @@ Usage:
   python scripts/sweep_non_ascii.py                    # dry-run, show what would change
   python scripts/sweep_non_ascii.py --apply            # write changes
   python scripts/sweep_non_ascii.py --apply file.md    # single file
+  python scripts/sweep_non_ascii.py --check            # CI gate: exit 1 if any prose violations
+
+In --check mode the script exits non-zero when a banned substitution character
+appears in prose (anything the sweep would rewrite). Characters inside code
+fences and inline backtick spans are intentionally preserved and never fail the
+check.
 """
 import re
 import subprocess
@@ -102,8 +108,9 @@ def process_file(path: Path, apply: bool) -> tuple[int, int]:
     return changed, skipped
 
 
-def main() -> None:
+def main() -> int:
     apply = '--apply' in sys.argv
+    check = '--check' in sys.argv
     extra_args = [a for a in sys.argv[1:] if not a.startswith('--')]
 
     if extra_args:
@@ -133,6 +140,20 @@ def main() -> None:
             total_changed += changed
             total_skipped += skipped
 
+    if check:
+        if total_changed > 0:
+            print(
+                f'\nCHECK FAILED: {total_changed} banned substitution character(s) in prose '
+                f'across {touched_files} file(s).\n'
+                f'Fix with: python scripts/sweep_non_ascii.py --apply'
+            )
+            return 1
+        print(
+            f'\nCHECK PASSED: no banned substitution characters in prose. '
+            f'({total_skipped} preserved inside code fences/spans.)'
+        )
+        return 0
+
     mode = 'Applied' if apply else 'Dry-run'
     print(
         f'\n{mode}: {total_changed} line(s) across {touched_files} file(s). '
@@ -140,7 +161,8 @@ def main() -> None:
     )
     if not apply:
         print('Run with --apply to write changes.')
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -76,3 +76,40 @@ def test_vault_health_json_reports_clean_linked_vault(tmp_path):
     assert payload["total_issues"] == 0
     assert payload["counts"]["Broken links"] == 0
     assert payload["counts"]["Orphans"] == 0
+
+
+def test_substitution_check_passes_on_repo():
+    """The repo source must be free of banned substitution characters in prose
+    (the CI gate). Characters inside code fences/spans are allowed."""
+    result = subprocess.run(
+        [sys.executable, "scripts/sweep_non_ascii.py", "--check"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_substitution_check_flags_prose_em_dash(tmp_path):
+    """--check must fail (exit 1) when a banned character appears in prose, and
+    must NOT fail when it only appears inside an inline code span."""
+    # Build the em-dash from its code point so this test's own source stays
+    # ASCII (the CI gate scans .py files too); the written fixtures get the
+    # real character.
+    em = "\u2014"
+    bad = tmp_path / "bad.md"
+    bad.write_text(f"A prose line with an em{em}dash.\n", encoding="utf-8")
+    flagged = subprocess.run(
+        [sys.executable, "scripts/sweep_non_ascii.py", "--check", str(bad)],
+        cwd=REPO_ROOT, check=False, capture_output=True, text=True,
+    )
+    assert flagged.returncode == 1, flagged.stdout
+
+    ok = tmp_path / "ok.md"
+    ok.write_text(f"A filename in code: `2026-01-01 {em} note.md` is fine.\n", encoding="utf-8")
+    passed = subprocess.run(
+        [sys.executable, "scripts/sweep_non_ascii.py", "--check", str(ok)],
+        cwd=REPO_ROOT, check=False, capture_output=True, text=True,
+    )
+    assert passed.returncode == 0, passed.stdout


### PR DESCRIPTION
The repo already had `scripts/sweep_non_ascii.py` (fixer) and the write-time `validate-ai-first.sh` hook (vault notes only). The gap was a **CI gate on the repo's own source** - the stray em-dashes I kept finding during the fork-merge waves had no automated guard.

## What this adds
- **`--check` mode** on `sweep_non_ascii.py`: exits 1 if a banned substitution character (em-dash, en-dash, curly quotes, Unicode math, ellipsis, NBSP) appears in prose in any tracked `.md`/`.py`/`.sh` file. Characters inside code fences / inline backtick spans are preserved and never fail (so filename examples and the anti-pattern table are fine).
- **CI step** in `.github/workflows/ci.yml` running the check on every push + PR.
- **Two smoke tests** locking the behavior (clean passes, prose em-dash fails, code-span char passes).

Reuses the existing sweep logic rather than adding a second linter. The repo is already clean, so the gate is green from the start. Generalizes the johanvillalbab fork's em-dash-only idea to the full banned set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)