### PR TITLE
Feat/projects command and bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **`/obsidian-projects` - live project status from git + local docs.** Reads `_CLAUDE.md` for the projects folder path, scans it for notes with `type: project` or a `repo:` field, and spawns a parallel subagent per project that checks the vault note, runs `git log` / `git status` (if a `repo:` path is set), and reads `NOTES.md` / `TODO.md` in the repo root. Merges the three into one status block (active / stalled / idle / blocked / archived inferred from activity recency), prints the full overview to the conversation ordered active-first, and injects a `## Last overview` section into each project note. An optional argument narrows the run to one named project. No central config block required - repo path lives in each note's `repo:` field, folder path comes from `_CLAUDE.md`. Four `.base` templates added to `references/bases/` (projects, people, tasks, daily) with `{{FOLDER}}` placeholders; `/obsidian-init` and `bootstrap_vault.py` stamp the correct paths at vault creation time and never touch the files again.
+
 ### Changed
 
 - **SEO / AEO / GEO / LLM refresh - every discoverability surface brought current with v0.10.0 (43 commands, The Architect).** The JSON-LD `SoftwareApplication` description now leads with `/obsidian-architect` + key-less research and gained `featureList` and `releaseNotes`. Added a **`FAQPage` JSON-LD** (six Q&As incl. "Can it document my codebase?") so answer engines / AI Overviews can extract and cite. `_config.yml` Pages description 34 -> 43 and re-pointed at the architect angle. `llms.txt`: intro now surfaces `/obsidian-architect` and key-less research, and the release history is completed (v0.8.0, v0.9.0, v0.10.0). README gained FAQs on documenting a codebase and the refresh-safe sentinel behavior. GitHub About description and the bug-report version placeholder refreshed. (The `examples/sample-vault/` "v0.9.0" mentions are a fictional sample app, intentionally left.)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/eugeniughelbur/obsidian-second-brain">
-    <img src="media/banner.png" alt="obsidian-second-brain: one brain, four CLIs, 43 commands. A cross-CLI skill for Obsidian that runs on Claude Code, Codex CLI, Gemini CLI, and OpenCode." width="100%" />
+    <img src="media/banner.png" alt="obsidian-second-brain: one brain, four CLIs, 44 commands. A cross-CLI skill for Obsidian that runs on Claude Code, Codex CLI, Gemini CLI, and OpenCode." width="100%" />
   </a>
 </p>
 
@@ -34,7 +34,7 @@
   <br /><br />
   <em>Every source updates existing pages instead of just appending new ones. Contradictions reconcile automatically. Your vault compounds while you sleep.</em>
   <br /><br />
-  <em>43 commands &middot; auto-synthesis &middot; thinking tools that argue with you</em>
+  <em>44 commands &middot; auto-synthesis &middot; thinking tools that argue with you</em>
   <br /><br />
   <em>live research from X, the web, and YouTube &middot; 4 scheduled agents &middot; 4 role presets</em>
   <br /><br />
@@ -241,7 +241,7 @@ Free transcript via youtube-transcript-api. Optional metadata + top comments via
   +------------------------------------------+
 ```
 
-43 commands total. The 3 Google Calendar commands (in Operations) are Claude Code only, so the Codex / Gemini / OpenCode builds ship 39.
+44 commands total. The 3 Google Calendar commands (in Operations) are Claude Code only, so the Codex / Gemini / OpenCode builds ship 40.
 
 **Layer 1** saves, organizes, ingests, reconciles, exports, schedules your calendar, and maintains your vault.
 **Layer 2** challenges your ideas, surfaces hidden patterns, bridges unrelated domains, and graduates ideas into projects.
@@ -251,7 +251,7 @@ Free transcript via youtube-transcript-api. Optional metadata + top comments via
 
 ---
 
-## 43 Commands
+## 44 Commands
 
 ### Operations -- Claude remembers
 
@@ -278,6 +278,7 @@ Free transcript via youtube-transcript-api. Optional metadata + top comments via
 | `/obsidian-review` | Structured weekly or monthly review |
 | `/obsidian-board` | Kanban board view and updates |
 | `/obsidian-project` | Project note with board and daily links |
+| `/obsidian-projects` | Live project status from git + local docs -- infers all context from vault notes, no config required |
 | `/obsidian-health` | Vault audit -- contradictions, gaps, stale claims, orphans |
 | `/obsidian-adr` | Decision records -- the vault knows why it's structured this way |
 | `/obsidian-visualize` | Generates a visual canvas map of your second brain |
@@ -643,7 +644,7 @@ An Obsidian plugin runs inside Obsidian and is written in TypeScript against Obs
 Run the one-line installer from the Install section below. It clones the repo to `~/.claude/skills/obsidian-second-brain` and symlinks the slash commands into `~/.claude/commands/` so Claude Code picks them up automatically. Restart Claude Code after install. The skill loads on every session that touches an Obsidian vault.
 
 ### Does this work with Codex CLI, Gemini CLI, or OpenCode?
-Yes. The repo ships a build script that compiles the platform-neutral source into four platform-specific outputs: Claude Code (slash commands + `CLAUDE.md`), Codex CLI (`AGENTS.md` + `.codex/commands/`), Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). Run `bash scripts/build.sh --platform codex-cli` (or another platform name), then copy the resulting `dist/<platform>/` tree into your vault. The non-Claude builds auto-generate a routing table that maps natural-language triggers to command files, so the same 39 cross-platform commands work no matter which CLI you use (the 3 Google Calendar commands are Claude Code only, since they depend on the claude.ai Calendar connector). The vault rules (AI-first notes, frontmatter, wikilinks, recency markers) are identical across all four platforms.
+Yes. The repo ships a build script that compiles the platform-neutral source into four platform-specific outputs: Claude Code (slash commands + `CLAUDE.md`), Codex CLI (`AGENTS.md` + `.codex/commands/`), Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). Run `bash scripts/build.sh --platform codex-cli` (or another platform name), then copy the resulting `dist/<platform>/` tree into your vault. The non-Claude builds auto-generate a routing table that maps natural-language triggers to command files, so the same 40 cross-platform commands work no matter which CLI you use (the 3 Google Calendar commands are Claude Code only, since they depend on the claude.ai Calendar connector). The vault rules (AI-first notes, frontmatter, wikilinks, recency markers) are identical across all four platforms.
 
 ### Does this work with Obsidian Sync?
 Yes. The skill writes to your vault as standard markdown files. Obsidian Sync, iCloud, Syncthing, and Git-based sync all work without modification.

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,7 +106,7 @@ See `references/vault-schema.md` for full structural details.
 ## Core Operating Principles
 
 ### AI-first vault rule (applies to every note)
-The vault is designed for **future-Claude** to read and reason over, not for human review. Every note Claude writes - across all 43 commands - must follow `references/ai-first-rules.md`:
+The vault is designed for **future-Claude** to read and reason over, not for human review. Every note Claude writes - across all 44 commands - must follow `references/ai-first-rules.md`:
 
 1. **Self-contained context** - each note explains itself; don't rely on backlinks alone
 2. **"For future Claude" preamble** - 2-3 sentence summary so Claude can decide relevance in 10 seconds
@@ -563,6 +563,16 @@ Steps:
 4. Fill in everything inferable from the conversation: description, goals, key people, current status
 5. Add a card to the relevant kanban board in the `📥 Backlog` or `🔨 In Progress` column
 6. Link from today's daily note
+
+---
+
+### `/obsidian-projects [optional: project name]`
+
+**Live status overview across all tracked projects.**
+
+Reads `_CLAUDE.md` for the projects folder, then scans it for notes with `type: project` or a `repo:` field. For each project, spawns a parallel subagent that runs three checks: reads the vault note (status, last activity, next action, blockers), runs `git log` and `git status` if a `repo:` path is set, and looks for `NOTES.md` / `TODO.md` in the repo root. Merges the three into one status block (active / stalled / idle / blocked / archived inferred from activity recency), prints the full overview to the conversation ordered active-first, then injects a `## Last overview` section into each project note.
+
+If a project name argument is given, shows deep context for that one project only.
 
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: obsidian-second-brain
 description: >-
-  A 43-command cross-CLI skill that turns any Obsidian vault into a living
+  A 44-command cross-CLI skill that turns any Obsidian vault into a living
   AI-first second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini
   CLI, and OpenCode from one platform-neutral source. Vault management,
   thinking tools, scheduled agents, key-less web research, Google Calendar

--- a/commands/obsidian-init.md
+++ b/commands/obsidian-init.md
@@ -24,8 +24,21 @@ Use the obsidian-second-brain skill. Execute `/obsidian-init`:
    - Write `log.md` at the vault root as a thin pointer file: explains the per-day structure, points at `Logs/`, and ships the entry template (do NOT put log entries in `log.md` itself)
    - Write today's `Logs/YYYY-MM-DD.md` with the init entry: `**HH:MM** - init | Vault initialized with _CLAUDE.md, index.md, Logs/`
    - Per-day file format: frontmatter (`type: log`, `date`, `ai-first: true`) + `**HH:MM** - action | description` entries, append-only
-7. Write `_CLAUDE.md`, `index.md`, root `log.md` (pointer), and `Logs/YYYY-MM-DD.md` (today's entries)
-8. Confirm what was written and tell the user to restart their Claude session so the new files take effect
+7. Create `Bases/` at the vault root if it does not exist. Stamp the four premade base files from `~/.claude/skills/obsidian-second-brain/references/bases/`:
+
+   | Template | Output file | Obsidian-style folder | Wiki-style folder |
+   |---|---|---|---|
+   | `projects.base.template` | `Bases/Projects.base` | `Projects` | `wiki/projects` |
+   | `people.base.template` | `Bases/People.base` | `People` | `wiki/entities` |
+   | `tasks.base.template` | `Bases/Tasks.base` | `Tasks` | `wiki/tasks` |
+   | `daily.base.template` | `Bases/Daily.base` | `Daily` | `wiki/daily` |
+
+   Detect vault style from the folder structure discovered in step 1: if `wiki/` exists at the root, use wiki-style folder names; otherwise use obsidian-style. For each template, replace the `{{FOLDER}}` placeholder with the correct folder name, then write to `Bases/`.
+
+   Skip any base file that already exists in `Bases/` - never overwrite.
+
+8. Write `_CLAUDE.md`, `index.md`, root `log.md` (pointer), `Logs/YYYY-MM-DD.md` (today's entries), and any new `Bases/*.base` files
+9. Confirm what was written and tell the user to restart their Claude session so the new files take effect
 
 If `_CLAUDE.md` already exists: show a diff of what would change and ask before overwriting.
 If `index.md` already exists: regenerate it (it's always a fresh catalog of current vault state).

--- a/commands/obsidian-projects.md
+++ b/commands/obsidian-projects.md
@@ -1,0 +1,74 @@
+---
+description: Live project status from git + local docs - infers all context from vault notes, no config required
+category: vault
+triggers_en: ["projects overview", "project status", "what am I working on", "show projects"]
+---
+
+Use the obsidian-second-brain skill. Execute `/obsidian-projects $ARGUMENTS`:
+
+Optional argument: a specific project name. If given, show deep context for that one project only. If no argument, run the full overview for all tracked projects.
+
+## Step 1 - discover projects
+
+Read `_CLAUDE.md` to find the projects folder name (e.g. `Projects/` or `wiki/projects/`). If not defined, default to `Projects/`.
+
+Scan that folder for all `.md` files. For each file, read its frontmatter. A note is a tracked project if it has `type: project` OR lives in the projects folder and has a `repo:` field. Collect:
+
+- `vault_note` - the file path
+- `name` - from `name:` frontmatter or the filename
+- `repo` - from `repo:` frontmatter; absent means non-code project (git steps skip)
+- `status` - from `status:` frontmatter if present
+
+If the optional argument was given, filter to the matching project only.
+
+## Step 2 - gather state in parallel
+
+Spawn one subagent per project. Each agent runs three checks:
+
+**Vault check:**
+- Read the project note
+- Extract: `status`, most recent entry in any `Recent Activity` or `## Last overview` section, `next_action`, open questions, blockers
+
+**Git check** (skip if no `repo:` field):
+- `git -C "<repo>" log --oneline --no-merges -15`
+- `git -C "<repo>" status --short`
+- If the path doesn't exist or isn't a git repo, note it and skip
+
+**Docs check** (skip if no `repo:` field):
+- Look for `NOTES.md`, `TODO.md`, `docs/NOTES.md`, `docs/TODO.md` in the repo root
+- Read the first one found; skip if none exist
+- Extract explicit next steps, blockers, or context not in the vault note
+
+## Step 3 - synthesize per project
+
+Merge the three agent results into one status block per project:
+
+- **Status**: infer from activity recency: `active` (commits or vault update in last 7 days), `stalled` (7-30 days), `idle` (30+ days), `blocked` (explicit blocker found). Override with the note's `status:` field if it says `archived` or `paused`.
+- **Last session**: what was worked on and when. Prefer git commit dates + messages over vault dates.
+- **Next action**: single most concrete next step. Pull from vault open questions or docs TODO. If unclear, say so - do not invent one.
+- **Blocked by**: anything explicitly blocking. `none` if nothing found.
+
+## Step 4 - print to conversation
+
+Print the full overview in the conversation immediately. Order: active first, then stalled, then idle, then archived. Use this format per project:
+
+```
+## [Project Name]
+Status: active | stalled | idle | blocked | archived
+Repo: path/to/repo  (or "no repo")
+Vault: [[Projects/Project Name]]
+
+Last session: YYYY-MM-DD - one sentence on what was done (source: git / vault / docs)
+Next action: specific next step, or "unclear - check vault note"
+Blocked by: none | description
+```
+
+## Step 5 - update vault notes
+
+For each project note, inject or overwrite a `## Last overview` section with the synthesized status and timestamp. This makes the note self-aware of when it was last reviewed.
+
+If a project note doesn't exist yet but was discoverable via git (e.g. the repo folder exists but has no matching vault note), mention it at the end as "untracked repos found". Do not create notes automatically.
+
+---
+
+**AI-first rule:** Every vault write MUST follow `references/ai-first-rules.md` — `## For future Claude` preamble, rich frontmatter, `[[wikilinks]]` for every project referenced, recency markers on git-sourced facts (e.g. `(as of 2026-05-21, git log)`), sources noted inline.

--- a/commands/obsidian-projects.md
+++ b/commands/obsidian-projects.md
@@ -65,10 +65,21 @@ Blocked by: none | description
 
 ## Step 5 - update vault notes
 
-For each project note, inject or overwrite a `## Last overview` section with the synthesized status and timestamp. This makes the note self-aware of when it was last reviewed.
+For each project note, inject or overwrite a `## Last overview` section with the synthesized status and timestamp. This makes the note self-aware of when it was last reviewed. Use this format:
+
+```markdown
+## Last overview
+
+**Reviewed:** YYYY-MM-DD (source: /obsidian-projects)
+
+**Status:** active | stalled | idle | blocked | archived
+**Last session:** YYYY-MM-DD - one sentence on what was done (source: git | vault | docs)
+**Next action:** specific next step, or "unclear - check vault note"
+**Blocked by:** none | description
+```
 
 If a project note doesn't exist yet but was discoverable via git (e.g. the repo folder exists but has no matching vault note), mention it at the end as "untracked repos found". Do not create notes automatically.
 
 ---
 
-**AI-first rule:** Every vault write MUST follow `references/ai-first-rules.md` — `## For future Claude` preamble, rich frontmatter, `[[wikilinks]]` for every project referenced, recency markers on git-sourced facts (e.g. `(as of 2026-05-21, git log)`), sources noted inline.
+**AI-first rule:** Every vault write MUST follow `references/ai-first-rules.md` - `## For future Claude` preamble, rich frontmatter, `[[wikilinks]]` for every project referenced, recency markers on git-sourced facts (e.g. `(as of 2026-05-21, git log)`), sources noted inline.

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,12 @@
 # obsidian-second-brain
 
-> A cross-CLI skill that turns any Obsidian vault into a self-rewriting second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini CLI, and OpenCode from one platform-neutral source via a build-time adapter pattern. An evolution of Karpathy's LLM Wiki pattern (https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): every source updates existing pages instead of just appending, contradictions reconcile automatically, and 4 scheduled agents maintain the vault while you sleep. 43 commands span vault management, thinking tools, scheduled agents, and a research toolkit (live X posts via Grok, web research via Perplexity, YouTube transcripts, podcast episodes via RSS or Whisper, and vault-grounded synthesis via Gemini File Search), plus a write-time AI-first validator hook and a `/create-command` interview flow for user-built extensions. As of v0.10 ("The Architect"), `/obsidian-architect` also scans a codebase and writes maintained, self-refreshing architecture notes into the vault (so your code lives in the same brain as your ideas and decisions), and `/research` + `/research-deep` run key-less by default with free fallback sources.
+> A cross-CLI skill that turns any Obsidian vault into a self-rewriting second brain. Runs in Claude Code, OpenAI Codex CLI, Google Gemini CLI, and OpenCode from one platform-neutral source via a build-time adapter pattern. An evolution of Karpathy's LLM Wiki pattern (https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): every source updates existing pages instead of just appending, contradictions reconcile automatically, and 4 scheduled agents maintain the vault while you sleep. 44 commands span vault management, thinking tools, scheduled agents, and a research toolkit (live X posts via Grok, web research via Perplexity, YouTube transcripts, podcast episodes via RSS or Whisper, and vault-grounded synthesis via Gemini File Search), plus a write-time AI-first validator hook and a `/create-command` interview flow for user-built extensions. As of v0.10 ("The Architect"), `/obsidian-architect` also scans a codebase and writes maintained, self-refreshing architecture notes into the vault (so your code lives in the same brain as your ideas and decisions), and `/research` + `/research-deep` run key-less by default with free fallback sources.
 
 ## What this is
 
 obsidian-second-brain is an open-source skill (MIT license) for Obsidian users who use an AI CLI as their primary interface to their own knowledge. It treats the vault as a knowledge base optimized for AI retrieval rather than human reading. Every note follows an AI-first design rule: self-contained context, "For future Claude" preamble, rich machine-readable frontmatter, recency markers per claim, sources preserved verbatim, mandatory wikilinks, and confidence levels.
 
-The skill is platform-neutral. The same 43 commands run in Claude Code (slash commands + `CLAUDE.md`), OpenAI Codex CLI (`AGENTS.md` + `.codex/commands/`), Google Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). One codebase compiles into all four via `bash scripts/build.sh`.
+The skill is platform-neutral. The same 44 commands run in Claude Code (slash commands + `CLAUDE.md`), OpenAI Codex CLI (`AGENTS.md` + `.codex/commands/`), Google Gemini CLI (`GEMINI.md` + `.gemini/commands/`), and OpenCode (`AGENTS.md` + `.opencode/commands/`). One codebase compiles into all four via `bash scripts/build.sh`.
 
 Owner: Eugeniu Ghelbur. AI Automation Engineer at Single Grain.
 
@@ -39,10 +39,10 @@ The complete analysis of how this skill extends Karpathy's pattern, including th
 
 - "I rebuilt Karpathy's LLM Wiki. Here's what's missing from the original." (2026-04-29). https://theaioperator.io/p/i-rebuilt-karpathys-llm-wiki-heres
 
-## The 43 commands (organized by category)
+## The 44 commands (organized by category)
 
-**Vault (16)** - daily writing, capture, find, kanban, calendar, recurring obligations, recall:
-obsidian-agenda, obsidian-board, obsidian-calendar, obsidian-capture, obsidian-daily, obsidian-find, obsidian-log, obsidian-meeting, obsidian-person, obsidian-project, obsidian-recap, obsidian-recurring, obsidian-save, obsidian-schedule, obsidian-task, obsidian-world. (obsidian-agenda / obsidian-schedule / obsidian-meeting / obsidian-calendar are Claude Code only - they use the Google Calendar MCP connector.)
+**Vault (17)** - daily writing, capture, find, kanban, calendar, recurring obligations, recall:
+obsidian-agenda, obsidian-board, obsidian-calendar, obsidian-capture, obsidian-daily, obsidian-find, obsidian-log, obsidian-meeting, obsidian-person, obsidian-project, obsidian-projects, obsidian-recap, obsidian-recurring, obsidian-save, obsidian-schedule, obsidian-task, obsidian-world. (obsidian-agenda / obsidian-schedule / obsidian-meeting / obsidian-calendar are Claude Code only - they use the Google Calendar MCP connector.)
 
 **Thinking (13)** - synthesis, decisions, learning, reviews, panels, discovery:
 obsidian-adr, obsidian-challenge, obsidian-connect, obsidian-decide, obsidian-emerge, obsidian-graduate, obsidian-learn, obsidian-panel, obsidian-reconcile, obsidian-review, obsidian-synthesize, idea-discovery, vault-deep-synthesis.
@@ -59,7 +59,7 @@ Plus 4 scheduled agents (morning, nightly, weekly, health-check) and 2 hook scri
 
 The repo is structured around a build-time adapter pattern:
 
-- `commands/` - 43 platform-neutral source files with frontmatter declaring `description`, `category` (vault/thinking/research/meta), `triggers_en` (natural-language trigger phrases), and an optional `exclude` (per-platform opt-out; the 3 Google Calendar commands set it to ship Claude Code only). The schema is extensible to other languages via `triggers_es`, `triggers_it`, `triggers_fr`, `triggers_de`, `triggers_pt`, `triggers_ru`, `triggers_ja`.
+- `commands/` - 44 platform-neutral source files with frontmatter declaring `description`, `category` (vault/thinking/research/meta), `triggers_en` (natural-language trigger phrases), and an optional `exclude` (per-platform opt-out; the 3 Google Calendar commands set it to ship Claude Code only). The schema is extensible to other languages via `triggers_es`, `triggers_it`, `triggers_fr`, `triggers_de`, `triggers_pt`, `triggers_ru`, `triggers_ja`.
 - `adapters/lib.sh` — shared parsing, path rewriting, tool-name neutralization, grouped routing-table emission, multilingual trigger emission.
 - `adapters/claude-code/adapter.sh` — identity copy (Claude Code's slash-command format matches the source).
 - `adapters/codex-cli/adapter.sh` — emits `AGENTS.md` with auto-generated routing table grouped by category and trigger phrase reference grouped by language. Commands go under `.codex/commands/`.
@@ -101,7 +101,7 @@ A `PostToolUse` hook (`hooks/validate-ai-first.sh`) enforces this at write time:
 
 ## Releases
 
-- v0.10.0 (2026-05-31) "The Architect": `/obsidian-architect` scans a codebase into maintained, self-refreshing architecture notes (sentinel-safe blocks never clobber hand-edits). Plus `/obsidian-calendar` reconciliation, `/vault-deep-synthesis`, `/idea-discovery`, `/obsidian-panel`, a Codex executable runner, a commit-decisions miner, and a substitution-character CI gate. 43 commands. https://github.com/eugeniughelbur/obsidian-second-brain/releases/tag/v0.10.0
+- v0.10.0 (2026-05-31) "The Architect": `/obsidian-architect` scans a codebase into maintained, self-refreshing architecture notes (sentinel-safe blocks never clobber hand-edits). Plus `/obsidian-calendar` reconciliation, `/vault-deep-synthesis`, `/idea-discovery`, `/obsidian-panel`, a Codex executable runner, a commit-decisions miner, and a substitution-character CI gate. 44 commands. https://github.com/eugeniughelbur/obsidian-second-brain/releases/tag/v0.10.0
 - v0.9.0 (2026-05-31): Free, key-less mode for `/research` and `/research-deep` (free fallback sources, no API key needed). Google Calendar commands. Anti-fabrication and false-absence guards. First automated tests + CI. Opt-in background agent. https://github.com/eugeniughelbur/obsidian-second-brain/releases/tag/v0.9.0
 - v0.8.0 (2026-05-15): `/notebooklm` rewritten on the Gemini File Search API (one HTTP call, no browser). https://github.com/eugeniughelbur/obsidian-second-brain/releases/tag/v0.8.0
 - v0.7.0 (2026-05-13): Multi-platform. 4 CLIs (Claude Code, Codex CLI, Gemini CLI, OpenCode) from one source via build-time adapter pattern. Command categorization with grouped dispatcher tables. Multilingual trigger schema (EN populated). Write-time AI-first validator hook. /create-command interview flow. https://github.com/eugeniughelbur/obsidian-second-brain/releases

--- a/references/bases/daily.base.template
+++ b/references/bases/daily.base.template
@@ -1,0 +1,18 @@
+filters:
+  and:
+    - file.inFolder("{{DAILY_FOLDER}}")
+    - file.ext == "md"
+    - note.type == "daily"
+properties:
+  tags:
+    displayName: Tags
+views:
+  - type: table
+    name: Recent
+    order:
+      - file.basename
+    direction: DESC
+    columnSize:
+      file.basename: 140
+  - type: calendar
+    name: Calendar

--- a/references/bases/people.base.template
+++ b/references/bases/people.base.template
@@ -1,0 +1,30 @@
+filters:
+  and:
+    - file.inFolder("{{PEOPLE_FOLDER}}")
+    - file.ext == "md"
+    - note.type == "person"
+formulas:
+  days_since_update: if(updated, (today() - date(updated)).days, "")
+properties:
+  formula.days_since_update:
+    displayName: Stale (days)
+  role:
+    displayName: Role
+  company:
+    displayName: Company
+  tags:
+    displayName: Tags
+views:
+  - type: table
+    name: All
+    order:
+      - file.basename
+      - role
+      - company
+      - tags
+      - updated
+      - formula.days_since_update
+    columnSize:
+      file.basename: 180
+      role: 150
+      company: 150

--- a/references/bases/projects.base.template
+++ b/references/bases/projects.base.template
@@ -1,0 +1,87 @@
+filters:
+  and:
+    - file.inFolder("{{PROJECTS_FOLDER}}")
+    - file.ext == "md"
+    - note.type == "project"
+formulas:
+  status_icon: if(status == "active", "🟢", if(status == "stalled", "🟡", if(status == "planning", "⚪", if(status == "on-hold", "⏸️", if(status == "completed", "✅", if(status == "archived", "📦", "❔"))))))
+  days_since_update: if(updated, (today() - date(updated)).days, "")
+properties:
+  formula.status_icon:
+    displayName: " "
+  formula.days_since_update:
+    displayName: Stale (days)
+  status:
+    displayName: Status
+  tags:
+    displayName: Tags
+  repo:
+    displayName: Repo
+views:
+  - type: table
+    name: Active
+    filters:
+      and:
+        - status == "active"
+    order:
+      - formula.status_icon
+      - file.basename
+      - tags
+      - updated
+    columnSize:
+      formula.status_icon: 40
+      file.basename: 183
+  - type: table
+    name: Stalled
+    filters:
+      and:
+        - status == "stalled"
+    order:
+      - file.basename
+      - tags
+      - updated
+      - formula.days_since_update
+  - type: table
+    name: Planning
+    filters:
+      and:
+        - status == "planning"
+    order:
+      - file.basename
+      - tags
+      - created
+      - repo
+  - type: table
+    name: On Hold
+    filters:
+      or:
+        - status == "on-hold"
+    order:
+      - file.basename
+      - tags
+      - updated
+      - formula.days_since_update
+  - type: table
+    name: Archived
+    filters:
+      and:
+        - status == "archived"
+    order:
+      - file.basename
+      - tags
+      - updated
+  - type: table
+    name: All
+    groupBy:
+      property: status
+      direction: ASC
+    order:
+      - formula.status_icon
+      - file.basename
+      - status
+      - tags
+      - updated
+      - formula.days_since_update
+    columnSize:
+      formula.status_icon: 70
+      file.basename: 165

--- a/references/bases/tasks.base.template
+++ b/references/bases/tasks.base.template
@@ -1,0 +1,61 @@
+filters:
+  and:
+    - file.inFolder("{{TASKS_FOLDER}}")
+    - file.ext == "md"
+    - note.type == "task"
+formulas:
+  days_until_due: if(due, (date(due) - today()).days, "")
+  overdue: if(due, (today() - date(due)).days > 0, false)
+properties:
+  formula.days_until_due:
+    displayName: Due in (days)
+  formula.overdue:
+    displayName: Overdue
+  status:
+    displayName: Status
+  priority:
+    displayName: Priority
+  due:
+    displayName: Due
+  project:
+    displayName: Project
+  tags:
+    displayName: Tags
+views:
+  - type: table
+    name: Open
+    filters:
+      and:
+        - status != "done"
+        - status != "cancelled"
+    order:
+      - formula.overdue
+      - due
+      - priority
+      - file.basename
+      - project
+    columnSize:
+      file.basename: 200
+      project: 150
+  - type: table
+    name: Done
+    filters:
+      and:
+        - status == "done"
+    order:
+      - updated
+      - file.basename
+  - type: table
+    name: All
+    groupBy:
+      property: status
+      direction: ASC
+    order:
+      - priority
+      - due
+      - file.basename
+      - project
+      - tags
+    columnSize:
+      file.basename: 200
+      project: 150

--- a/scripts/bootstrap_vault.py
+++ b/scripts/bootstrap_vault.py
@@ -45,6 +45,30 @@ for _stream in (sys.stdout, sys.stderr):
 TODAY = date.today().isoformat()
 YEAR = date.today().year
 
+TEMPLATE_DIR = Path(__file__).parent.parent / "references" / "bases"
+
+# Maps template filename → (output filename, placeholder to replace)
+BASE_TEMPLATES: dict[str, tuple[str, str]] = {
+    "projects.base.template": ("Projects.base", "{{PROJECTS_FOLDER}}"),
+    "people.base.template":   ("People.base",   "{{PEOPLE_FOLDER}}"),
+    "tasks.base.template":    ("Tasks.base",    "{{TASKS_FOLDER}}"),
+    "daily.base.template":    ("Daily.base",    "{{DAILY_FOLDER}}"),
+}
+
+OBSIDIAN_FOLDERS = {
+    "{{PROJECTS_FOLDER}}": "Projects",
+    "{{PEOPLE_FOLDER}}":   "People",
+    "{{TASKS_FOLDER}}":    "Tasks",
+    "{{DAILY_FOLDER}}":    "Daily",
+}
+
+WIKI_FOLDERS = {
+    "{{PROJECTS_FOLDER}}": "wiki/projects",
+    "{{PEOPLE_FOLDER}}":   "wiki/entities",
+    "{{TASKS_FOLDER}}":    "wiki/tasks",
+    "{{DAILY_FOLDER}}":    "wiki/daily",
+}
+
 
 # ── Preset definitions ────────────────────────────────────────────────────────
 # Each preset declares its folder list, kanban boards, _CLAUDE.md folder map,
@@ -112,6 +136,37 @@ def write(path: Path, content: str):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content.strip() + "\n", encoding="utf-8")
     print(f"  ✓ {path}")
+
+
+def write_bases(vault: Path, style: str = "obsidian", preset_folders: list[str] | None = None) -> None:
+    """Create Bases/ with premade .base files stamped for the vault style.
+
+    Skips any base whose target folder is absent from the preset and never
+    overwrites an existing file — safe to call on re-runs.
+    """
+    folder_map = WIKI_FOLDERS if style == "wiki" else OBSIDIAN_FOLDERS
+    bases_dir = vault / "Bases"
+    bases_dir.mkdir(exist_ok=True)
+
+    for template_name, (output_name, placeholder) in BASE_TEMPLATES.items():
+        target = bases_dir / output_name
+        if target.exists():
+            continue
+
+        folder = folder_map[placeholder]
+        if preset_folders is not None and not any(
+            f == folder or f.startswith(folder + "/") for f in preset_folders
+        ):
+            continue
+
+        template_path = TEMPLATE_DIR / template_name
+        if not template_path.exists():
+            print(f"  ⚠️  template not found: {template_path}")
+            continue
+
+        content = template_path.read_text(encoding="utf-8")
+        target.write_text(content.replace(placeholder, folder), encoding="utf-8")
+        print(f"  ✓ {target}")
 
 
 def render_kanban(columns: list) -> str:
@@ -1128,6 +1183,10 @@ def bootstrap(vault: Path, name: str, preset_key: str, mode: str, subject: str,
     write_core_templates(vault)
     write_preset_extras(vault, preset_key)
 
+    # ── Bases ─────────────────────────────────────────────────────────────────
+    write_bases(vault, style="obsidian", preset_folders=folders)
+    print("📊 Bases created")
+
     # ── .obsidian stub ────────────────────────────────────────────────────────
     (vault / ".obsidian").mkdir(exist_ok=True)
     if not (vault / ".obsidian/app.json").exists():
@@ -1135,7 +1194,7 @@ def bootstrap(vault: Path, name: str, preset_key: str, mode: str, subject: str,
 
     print(f"\n✅ Vault bootstrapped at: {vault}")
     print("\n📋 Recommended Obsidian plugins:")
-    print("   • Dataview  - powers the dashboard queries")
+    print("   • Bases     - powers the Bases/ live views (core plugin, enable in Settings)")
     print("   • Templater - powers the Templates/ folder")
     print("   • Kanban    - powers the Boards/ folder")
     print("   • Calendar  - daily note navigation")

--- a/scripts/bootstrap_vault.py
+++ b/scripts/bootstrap_vault.py
@@ -142,7 +142,7 @@ def write_bases(vault: Path, style: str = "obsidian", preset_folders: list[str] 
     """Create Bases/ with premade .base files stamped for the vault style.
 
     Skips any base whose target folder is absent from the preset and never
-    overwrites an existing file — safe to call on re-runs.
+    overwrites an existing file - safe to call on re-runs.
     """
     folder_map = WIKI_FOLDERS if style == "wiki" else OBSIDIAN_FOLDERS
     bases_dir = vault / "Bases"


### PR DESCRIPTION
## What this PR does

Adds `/obsidian-projects` - a live project status command that reads vault
notes, runs `git log` / `git status` per repo, and checks local docs files,
then prints a full overview to the conversation and stamps a `## Last overview`
section into each project note. Also adds four `.base` templates in
`references/bases/` (projects, people, tasks, daily) with `{{FOLDER}}`
placeholders that `/obsidian-init` and `bootstrap_vault.py` stamp at vault
creation time.

Design approved in discussion #24. Rebased onto current main.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] New slash command
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Breaking change (fix or feature that changes existing behavior)

## Related issues

Related to #24

## How I tested it

Ran `/obsidian-projects` against a local vault (mix of
local repos, GitHub-only repos, and no-repo entries). Confirmed: status
inferred from git commit dates and vault `updated:` field rather than
trusting stale frontmatter; `## Last overview` injected into 6 notes;
git-missing local paths noted rather than errored; GitHub URLs skipped for
git check as expected.

## AI-first rule compliance (required for any vault-writing command)

- [x] My changes follow `references/ai-first-rules.md`
- [x] If I added or changed a command that writes to the vault, the produced note has a `## For future Claude` preamble
- [x] Frontmatter includes `ai-first: true`, `type:`, `date:`, `tags:`
- [x] Wikilinks (`[[...]]`) used for every person, project, idea, decision referenced
- [x] External claims have recency markers (`(as of YYYY-MM, source.com)`)
- [x] Sources preserved verbatim (URLs inline, not paraphrased)

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [x] I updated the README or docs if user-facing behavior changed
- [x] I updated `CHANGELOG.md` (under "Unreleased") if applicable
- [x] If I added a new command, I added an entry in `SKILL.md` and the README's command table

## Screenshots / output (if visual or producing notes)

**Command output (live run, two representative entries):**

```
## hearth
Status: active
Repo: https://github.com/MPZ-00/hearth
Vault: [[Projects/hearth]]

Last session: 2026-06-02 - v0.2.0 tagged and pushed; added /dev update subcommand and invite link in /help embed (source: vault)
Next action: unclear - check vault note
Blocked by: none

## obsidian-second-brain
Status: active
Repo: https://github.com/MPZ-00/obsidian-second-brain
Vault: [[Projects/obsidian-second-brain]]

Last session: 2026-06-02 - rebased feat/projects-command-and-bases onto main, renamed command to /obsidian-projects, updated docs (source: git)
Next action: open PR to upstream
Blocked by: none
```

**Injected `## Last overview` block (Projects/hearth.md after the run):**

```markdown
## Last overview

**Reviewed:** 2026-06-02 (source: /obsidian-projects)

**Status:** active
**Last session:** 2026-06-02 - v0.2.0 tagged and pushed; /dev update subcommand and invite link in /help added (source: vault)
**Next action:** unclear - check vault note for v0.3.0 scope
**Blocked by:** none
```