### PR TITLE
Fix stale command count in CLAUDE.md (32 -> 44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 Operating instructions for Claude Code when working inside this repo.
 
-This is the source repo for **obsidian-second-brain**, a Claude Code skill that turns any Obsidian vault into a living AI-first second brain. The skill ships 32 slash commands across 4 layers (vault management, thinking tools, research toolkit, scheduled agents).
+This is the source repo for **obsidian-second-brain**, a Claude Code skill that turns any Obsidian vault into a living AI-first second brain. The skill ships 44 slash commands across 4 layers (vault management, thinking tools, research toolkit, scheduled agents).
 
 If you are Claude operating on a user's vault, you want `_CLAUDE.md` inside their vault, not this file. This file is for working on the skill's source code.
 
 ## Repo layout
 
-- `commands/` - 32 slash command definitions, one `.md` per command. **This is the platform-neutral source.** Adapters compile it for each platform.
+- `commands/` - 44 slash command definitions, one `.md` per command. **This is the platform-neutral source.** Adapters compile it for each platform.
 - `references/` - shared specs that commands link to. **`ai-first-rules.md` is the canonical vault-write spec** and is non-negotiable.
 - `scripts/` - Python helpers (`bootstrap_vault.py`, `vault_health.py`, the `research/` toolkit), plus `build.sh` (the adapter orchestrator) and `lib.sh`.
 - `adapters/` - platform translation layer. `lib.sh` holds shared parsing helpers. `claude-code/`, `codex-cli/`, `gemini-cli/`, `opencode/` each ship an `adapter.sh`.


### PR DESCRIPTION
## What this PR does

`CLAUDE.md` still said "32 slash commands" in two places, but `commands/` holds 44 `.md` files and the rest of the docs (`SKILL.md`, `README.md`, `architecture.md`, `llms.txt`) already say 44. This updates both occurrences in `CLAUDE.md` to 44 so the contributor-facing doc matches the repo. Count only — the "4 layers" wording is left untouched.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [x] 📚 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

n/a — per CONTRIBUTING ("No issue required for typo fixes - just open a PR").

## How I tested it

- `find commands -maxdepth 1 -name '*.md' | wc -l` → 44 (no subfolders, no non-`.md` files in `commands/`).
- Cross-checked the count across docs: `SKILL.md:109`, `README.md:3,37,244`, `architecture.md:13,56`, and `llms.txt` already say 44; only `CLAUDE.md:5,11` still said 32.

## AI-first rule compliance (required for any vault-writing command)

n/a — docs-only change; no command added or changed, no vault write touched.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [ ] I updated the README or docs if user-facing behavior changed (no behavior change)
- [ ] I updated `CHANGELOG.md` (under "Unreleased") if applicable (docs count fix; not applicable)
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table (n/a)
