### PR TITLE
Fix stale command count in CONTRIBUTING.md and examples (31 -> 44)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Now restart Claude Code and your slash commands will use the local checkout.
 
 ### ✨ New slash commands
 
-This is the most common contribution. The skill currently has 31 commands across 4 layers; adding a 32nd is a clear path.
+This is the most common contribution. The skill currently has 44 commands across 4 layers; adding a 45th is a clear path.
 
 **Required steps:**
 1. **Open a feature request issue first.** Get a thumbs-up before building. Saves you wasted work if the command isn't a fit.
@@ -131,7 +131,7 @@ triggers_es: ["guarda esto", "guarda la conversación", "guarda al vault"]
 
 When you rebuild (`bash scripts/build.sh`), the new language automatically appears as its own section under `## Trigger phrases` in the dispatcher files (`AGENTS.md`, `GEMINI.md`). No adapter code changes needed.
 
-Translation PRs welcome for any of the 31 commands. Send one language at a time, full coverage. Open `commands/*.md`, add your `triggers_<code>:` line under the existing `triggers_en:`, and open a PR titled `Add <Language> trigger phrases`.
+Translation PRs welcome for any of the 44 commands. Send one language at a time, full coverage. Open `commands/*.md`, add your `triggers_<code>:` line under the existing `triggers_en:`, and open a PR titled `Add <Language> trigger phrases`.
 
 ### 🐧 Cross-platform support
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ Everything here is fictional. **Alex Rivera**, **Sam Patel**, **Tide**, **Curren
 
 ## How to use this for your own vault
 
-You don't copy this folder into your vault. The skill builds your vault for you when you run `/obsidian-init` and grows it through normal usage of the 31 commands. This folder exists only to show what the output looks like before you install.
+You don't copy this folder into your vault. The skill builds your vault for you when you run `/obsidian-init` and grows it through normal usage of the 44 commands. This folder exists only to show what the output looks like before you install.
 
 If you want a clean starting point, run:
 


### PR DESCRIPTION
## What this PR does

`CONTRIBUTING.md` (×2) and `examples/README.md` (×1) still describe the skill as having "31 commands", but `commands/` holds 44 `.md` files. This updates those present-tense, current-state claims to 44 (and the "adding a 32nd" follow-on to "a 45th"). Companion to #64, which fixed the same stale count in `CLAUDE.md`.

Deliberately left untouched: `CHANGELOG.md` entries that mention 31/26/32 (append-only historical records of past releases) and `architecture.md`'s counts (current, and explicitly pinned to commit `ff0319c`).

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [x] 📚 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

n/a — per CONTRIBUTING ("No issue required for typo fixes - just open a PR").

## How I tested it

- `git ls-tree -r --name-only main commands/ | grep -c '\.md$'` → 44.
- Separated current-state claims (fixed here) from historical ones: every `31` in `CHANGELOG.md` describes a past release and was left as-is; `architecture.md` is current and pinned to a commit; the `31` in `llms.txt` is a date (`2026-05-31`), not a count; `FORK_INSIGHTS.md` `31.` is a list index.
- Confirmed all 44 commands carry `triggers_en:` (44/44), so "any of the 44 commands" in the translation section is accurate.

## AI-first rule compliance (required for any vault-writing command)

n/a — docs-only change; no command added or changed, no vault write touched.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [ ] I updated the README or docs if user-facing behavior changed (no behavior change)
- [ ] I updated `CHANGELOG.md` (under "Unreleased") if applicable (docs count fix; not applicable)
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table (n/a)
