### PR TITLE
fix: exclude .claude directory from vault health scan

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -26,7 +26,7 @@ from datetime import date
 from pathlib import Path
 
 TODAY = date.today()
-EXCLUDE_DIRS = {".obsidian", ".trash", "_trash", ".git", "Templates"}
+EXCLUDE_DIRS = {".obsidian", ".trash", "_trash", ".git", ".claude", "Templates"}
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 # A note whose entire body was accidentally saved inside a ```markdown code fence:
 # the first non-blank line opens a fence and the real frontmatter (---) lives INSIDE it.


### PR DESCRIPTION
## Problem

The health script scans `.claude/` notes (1,876 total) instead of only real vault notes (1,664), inflating every category.

## Fix

Add `.claude` to `EXCLUDE_DIRS` alongside `.obsidian`, `.trash`, `_trash`, `.git`, and `Templates`.

Fixes #80