### PR TITLE
fix(mcp): guard get_skill against path traversal

### DIFF
--- a/integrations/obsidian-mcp-server/vault_ops.py
+++ b/integrations/obsidian-mcp-server/vault_ops.py
@@ -485,6 +485,11 @@ def get_skill(name: str) -> Dict[str, Any]:
     name = (name or "").strip().lstrip("/")
     if not name:
         return {"error": "name is required"}
+    # Path-traversal guard: skill names are flat slugs (alphanumerics, '-' and '_').
+    # Rejecting separators and dots stops a crafted name like "../../etc/passwd" from
+    # escaping the commands/ dir, since lstrip("/") alone does not remove ".." segments.
+    if not all(c.isalnum() or c in "-_" for c in name):
+        return {"error": f"unknown skill: {name}"}
     if name in _EXCLUDED_SKILLS:
         return {"error": f"skill '{name}' is not exposed over MCP"}
     cmds = _commands_dir()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -467,6 +467,19 @@ def test_mcp_vault_ops_skills_exclude_niche(monkeypatch):
     assert "instructions" in vault_ops.get_skill("obsidian-save")
 
 
+def test_mcp_vault_ops_get_skill_rejects_path_traversal(monkeypatch):
+    """get_skill must reject names that are not flat slugs, so a crafted name
+    cannot escape the commands/ dir via path traversal (lstrip('/') alone does
+    not remove '..' segments)."""
+    vault_ops = _load_vault_ops()
+    for bad in ("../../etc/passwd", "foo/bar", "a.b", "../obsidian-save", "with space"):
+        res = vault_ops.get_skill(bad)
+        assert res.get("error"), f"expected error for {bad!r}"
+        assert "instructions" not in res
+    # a legitimate flat slug still resolves
+    assert "instructions" in vault_ops.get_skill("obsidian-save")
+
+
 def test_mcp_vault_ops_update_note_guarded_edit(tmp_path, monkeypatch):
     """update_note appends a section and merges scalar frontmatter on an existing
     note, preserves the tags block, stamps `updated`, and refuses a path escape


### PR DESCRIPTION
## What

`get_skill(name)` in the MCP connector builds `commands/<name>.md` after only `name.strip().lstrip("/")`, an `_EXCLUDED_SKILLS` check, and `is_file()`. Because `lstrip("/")` does not strip `..` path segments, a crafted name such as `../../<file>` could resolve a file outside the `commands/` directory.

`read_note` already guards against escaping the vault (resolve() + parent check); `get_skill` had no equivalent.

## Fix

Add a flat-slug allowlist — skill names are `[A-Za-z0-9_-]` — and reject anything containing a separator or dot before the path is constructed:

```python
if not all(c.isalnum() or c in "-_" for c in name):
    return {"error": f"unknown skill: {name}"}
```

## Test

Adds `test_mcp_vault_ops_get_skill_rejects_path_traversal`: traversal / dotted / separator / whitespace names all error out and leak no `instructions`, while a legitimate slug (`obsidian-save`) still resolves. Full suite green (28 passed).