### PR TITLE
fix: exclude numbered template folders (20_Templates/) from vault health scan

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -54,7 +54,9 @@ def load_vault(vault: Path) -> dict:
     notes = {}
     for md in vault.rglob("*.md"):
         parts = md.relative_to(vault).parts
-        if any(p in EXCLUDE_DIRS for p in parts):
+        # ponytail: also skip any template folder (Templates, 20_Templates, ...) —
+        # its <%...%> Templater syntax is intentional, not a "template leftover" bug.
+        if any(p in EXCLUDE_DIRS or p.lower().endswith("templates") for p in parts):
             continue
         rel = str(md.relative_to(vault))
         content = md.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Problem
`vault_health.py` only excludes a folder literally named `Templates`. Notes under numbered/prefixed template folders like `20_Templates/` are still scanned, so their intentional `<%...%>` Templater syntax is reported as critical "template leftover" issues.

## Fix
Exclude any path segment ending in `templates` (case-insensitive) - `Templates`, `20_Templates`, `99_Templates`, etc. One-line change in `load_vault()`.

## Impact
- Real vault: 5 false-positive critical findings -> 0.
- Smoke tests unaffected (temp vaults use no `*templates` folders).