### PR TITLE
docs: fix stale 45->44 command count in CONTRIBUTING.md and examples/README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Now restart Claude Code and your slash commands will use the local checkout.
 
 ### ✨ New slash commands
 
-This is the most common contribution. The skill currently has 45 commands across 4 layers; adding a 45th is a clear path.
+This is the most common contribution. The skill currently has 44 commands across 4 layers; adding a 45th is a clear path.
 
 **Required steps:**
 1. **Open a feature request issue first.** Get a thumbs-up before building. Saves you wasted work if the command isn't a fit.
@@ -131,7 +131,7 @@ triggers_es: ["guarda esto", "guarda la conversación", "guarda al vault"]
 
 When you rebuild (`bash scripts/build.sh`), the new language automatically appears as its own section under `## Trigger phrases` in the dispatcher files (`AGENTS.md`, `GEMINI.md`). No adapter code changes needed.
 
-Translation PRs welcome for any of the 45 commands. Send one language at a time, full coverage. Open `commands/*.md`, add your `triggers_<code>:` line under the existing `triggers_en:`, and open a PR titled `Add <Language> trigger phrases`.
+Translation PRs welcome for any of the 44 commands. Send one language at a time, full coverage. Open `commands/*.md`, add your `triggers_<code>:` line under the existing `triggers_en:`, and open a PR titled `Add <Language> trigger phrases`.
 
 ### 🐧 Cross-platform support
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ Everything here is fictional. **Alex Rivera**, **Sam Patel**, **Tide**, **Curren
 
 ## How to use this for your own vault
 
-You don't copy this folder into your vault. The skill builds your vault for you when you run `/obsidian-init` and grows it through normal usage of the 45 commands. This folder exists only to show what the output looks like before you install.
+You don't copy this folder into your vault. The skill builds your vault for you when you run `/obsidian-init` and grows it through normal usage of the 44 commands. This folder exists only to show what the output looks like before you install.
 
 If you want a clean starting point, run:
 


### PR DESCRIPTION
## Problem

CONTRIBUTING.md and examples/README.md still say "45 commands" in three places.
The repo ships 44 (`ls commands/*.md | wc -l`), and the June 29 sync commit
(bf63932) fixed the count in README.md, SKILL.md, architecture.md, CLAUDE.md,
and llms.txt. Its own message says "45->44 commands", but the diff skipped
CONTRIBUTING.md and examples/README.md.

## Fix

Three 45 -> 44 corrections:
- CONTRIBUTING.md:63 ("the skill currently has 45 commands")
- CONTRIBUTING.md:134 ("Translation PRs welcome for any of the 45 commands")
- examples/README.md:40 ("grows it through normal usage of the 45 commands")

Line 63's "adding a 45th is a clear path" stays unchanged: it refers to the
next command to be added, and 45 is right for that.

## Disclosure

I found and drafted this with Claude's help, and reviewed the diff myself
before submitting.
