### PR TITLE
fix(commands): use relative paths in obsidian-init and obsidian-health

### DIFF
--- a/commands/obsidian-health.md
+++ b/commands/obsidian-health.md
@@ -7,7 +7,7 @@ triggers_en: ["vault health", "check vault", "audit vault", "vault diagnostics"]
 Use the obsidian-second-brain skill. Execute `/obsidian-health`:
 
 1. Read `_CLAUDE.md` first to find the vault path
-2. Run: `python ~/.claude/skills/obsidian-second-brain/scripts/vault_health.py --path ~/path/to/vault --json`
+2. Run: `python scripts/vault_health.py --path ~/path/to/vault --json`
    (replace vault path with the one from `_CLAUDE.md`)
 3. Parse the JSON output and split findings into categories
 4. Spawn parallel subagents to handle each category simultaneously:

--- a/commands/obsidian-init.md
+++ b/commands/obsidian-init.md
@@ -13,7 +13,7 @@ Use the obsidian-second-brain skill. Execute `/obsidian-init`:
    - **Boards agent**: read all files in `Boards/`
    - **Samples agent**: read one existing note per major folder to capture naming conventions and frontmatter patterns
 3. Merge all agent results into a complete picture of the vault
-4. Generate a complete `_CLAUDE.md` using the template in `~/.claude/skills/obsidian-second-brain/references/claude-md-template.md`, filled with real values from the vault
+4. Generate a complete `_CLAUDE.md` using the template in `references/claude-md-template.md`, filled with real values from the vault
 5. Generate `index.md` at the vault root - a catalog of all pages organized by category:
    - List every note in the vault grouped by folder (Projects, People, Ideas, etc.)
    - Include a one-line description for each note (from frontmatter or first paragraph)
@@ -24,7 +24,7 @@ Use the obsidian-second-brain skill. Execute `/obsidian-init`:
    - Write `log.md` at the vault root as a thin pointer file: explains the per-day structure, points at `Logs/`, and ships the entry template (do NOT put log entries in `log.md` itself)
    - Write today's `Logs/YYYY-MM-DD.md` with the init entry: `**HH:MM** - init | Vault initialized with _CLAUDE.md, index.md, Logs/`
    - Per-day file format: frontmatter (`type: log`, `date`, `ai-first: true`) + `**HH:MM** - action | description` entries, append-only
-7. Create `Bases/` at the vault root if it does not exist. Stamp the four premade base files from `~/.claude/skills/obsidian-second-brain/references/bases/`:
+7. Create `Bases/` at the vault root if it does not exist. Stamp the four premade base files from `references/bases/`:
 
    | Template | Output file | Obsidian-style folder | Wiki-style folder |
    |---|---|---|---|
@@ -42,7 +42,7 @@ Use the obsidian-second-brain skill. Execute `/obsidian-init`:
 
 If `_CLAUDE.md` already exists: show a diff of what would change and ask before overwriting.
 If `index.md` already exists: regenerate it (it's always a fresh catalog of current vault state).
-If a monolithic `log.md` already exists with `## YYYY-MM-DD` sections: run `python ~/.claude/skills/obsidian-second-brain/scripts/migrate_log.py --vault <vault-path>` to split it into `Logs/YYYY-MM-DD.md` files. Do not overwrite manually.
+If a monolithic `log.md` already exists with `## YYYY-MM-DD` sections: run `python scripts/migrate_log.py --vault <vault-path>` to split it into `Logs/YYYY-MM-DD.md` files. Do not overwrite manually.
 
 ---
 


### PR DESCRIPTION
Replace absolute `~/.claude/skills/obsidian-second-brain/...` paths with relative paths (`references/...`, `scripts/...`) so the commands work on all platforms, not just Claude Code.

The `rewrite_platform_paths` step in `adapters/lib.sh` converts `.claude/` → `.opencode/` etc., but the full skill-install prefix `~/.claude/skills/obsidian-second-brain/` does not exist outside Claude Code — it produces broken paths like `~/.opencode/skills/obsidian-second-brain/...`.

All other 41 commands already use relative paths. These 2 were the only outliers.

Tested: `bash scripts/build.sh` passes on all 6 platforms, `uv run pytest -q` passes 29/29.