### PR TITLE
Add Spanish trigger phrases

### DIFF
--- a/commands/create-command.md
+++ b/commands/create-command.md
@@ -2,6 +2,7 @@
 description: Create a new obsidian-second-brain command via interview - zero markdown editing required
 category: meta
 triggers_en: ["create command", "new command", "add a command", "scaffold a command"]
+triggers_es: ["crea un comando", "nuevo comando", "añade un comando", "monta un comando"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/create-command $ARGUMENTS`:

--- a/commands/idea-discovery.md
+++ b/commands/idea-discovery.md
@@ -2,6 +2,7 @@
 description: Surface 3-5 next-direction candidates by reading ungraduated ideas, open project questions, and orphan research notes - what is worth working on next
 category: thinking
 triggers_en: ["what should I work on next", "idea discovery", "surface next directions", "what's worth pursuing"]
+triggers_es: ["¿en qué debería trabajar ahora?", "descubre ideas para seguir", "qué rumbos tomar", "qué vale la pena perseguir"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/idea-discovery`:

--- a/commands/notebooklm.md
+++ b/commands/notebooklm.md
@@ -2,6 +2,7 @@
 description: Vault-first source-grounded research via Gemini File Search. One command, no browser. The grounded parallel to /research-deep (which is open-web via Perplexity).
 category: research
 triggers_en: ["notebooklm", "research grounded", "ground research in vault", "ask my notebook", "source-grounded research"]
+triggers_es: ["notebooklm", "investigación fundamentada en mis notas", "basa esto en mi vault", "pregúntale a mis notas", "investigación con fuentes propias"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/notebooklm [topic]`:

--- a/commands/obsidian-architect.md
+++ b/commands/obsidian-architect.md
@@ -2,6 +2,7 @@
 description: Scan a codebase and write a maintained set of architecture notes into the vault - overview, per-module notes, key decisions. Re-run to refresh without clobbering your edits
 category: meta
 triggers_en: ["document this codebase", "architect this project", "map this code into my vault", "generate architecture notes", "refresh architecture docs"]
+triggers_es: ["documenta este código", "analiza la arquitectura de este proyecto", "lleva este código a mi vault", "genera notas de arquitectura", "actualiza la documentación de arquitectura"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-architect [path-to-codebase]`:

--- a/commands/obsidian-board-hygiene.md
+++ b/commands/obsidian-board-hygiene.md
@@ -2,6 +2,7 @@
 description: Bulk-triage a kanban board - surface stale items and archive, reschedule, or mark them done in one pass
 category: vault
 triggers_en: ["clean up my board", "triage my board", "board hygiene", "archive stale tasks", "my board is a mess"]
+triggers_es: ["limpia mi tablero", "haz triaje de mi tablero", "ordena el tablero", "archiva las tareas viejas", "mi tablero es un desastre"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-board-hygiene [board]`:

--- a/commands/obsidian-board.md
+++ b/commands/obsidian-board.md
@@ -2,6 +2,7 @@
 description: Show or update a kanban board - flags overdue items, updates from conversation
 category: vault
 triggers_en: ["show board", "kanban", "what is on my board", "update board"]
+triggers_es: ["muestra el tablero", "kanban", "qué hay en mi tablero", "actualiza el tablero"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-board $ARGUMENTS`:

--- a/commands/obsidian-calendar.md
+++ b/commands/obsidian-calendar.md
@@ -3,6 +3,7 @@ description: One calendar command with four modes - agenda (read a snapshot), re
 category: vault
 exclude: [codex-cli, gemini-cli, opencode, hermes]
 triggers_en: ["review my agenda", "check my calendar", "what's on my schedule", "what's on the calendar", "agenda for this week", "calendar check", "reconcile calendar", "what's not on my calendar", "am I missing anything on my calendar", "create a meeting note", "log this meeting", "meeting note for", "prep this meeting", "schedule a meeting", "book a meeting", "put this on my calendar", "schedule this task", "find a time for"]
+triggers_es: ["revisa mi agenda", "revisa mi calendario", "qué tengo esta semana", "concilia mi calendario con el vault", "qué me falta en el calendario", "crea una nota de reunión", "registra esta reunión", "prepárame para esta reunión", "agenda una reunión", "reserva una reunión", "pon esto en mi calendario", "agenda esta tarea", "búscame un hueco para"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-calendar $ARGUMENTS`:

--- a/commands/obsidian-capture.md
+++ b/commands/obsidian-capture.md
@@ -2,6 +2,7 @@
 description: Quick idea capture - zero friction, saves to your ideas folder and mentions in daily note
 category: vault
 triggers_en: ["capture this idea", "save this idea", "quick note", "drop a thought"]
+triggers_es: ["captura esta idea", "guarda esta idea", "nota rápida", "apunta esto"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-capture $ARGUMENTS`:

--- a/commands/obsidian-catchup.md
+++ b/commands/obsidian-catchup.md
@@ -2,6 +2,7 @@
 description: Review and process everything captured on the go from the Telegram journal bot - voice, text, images, PDFs, links - waiting in the catchup queue. You pull it when you are back at the laptop; nothing is processed autonomously.
 category: vault
 triggers_en: ["catch up", "catchup", "what did I dump from telegram", "process my captures", "go through my telegram dumps", "anything new from the phone", "process my catchup", "review what I captured", "what did I capture on the go"]
+triggers_es: ["ponme al día", "qué mandé por telegram", "procesa mis capturas", "revisa lo que capturé desde el móvil", "hay algo nuevo del móvil", "repasa mi cola de capturas"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-catchup $ARGUMENTS`:

--- a/commands/obsidian-challenge.md
+++ b/commands/obsidian-challenge.md
@@ -2,6 +2,7 @@
 description: Red-team your current idea against your own vault history - finds contradictions, past failures, and flawed assumptions
 category: thinking
 triggers_en: ["challenge this", "grill me on this", "red team my idea", "stress test this"]
+triggers_es: ["cuestiona esta idea", "ponme a prueba con esto", "haz de abogado del diablo con mi idea", "pon esto a prueba"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-challenge $ARGUMENTS`:

--- a/commands/obsidian-connect.md
+++ b/commands/obsidian-connect.md
@@ -2,6 +2,7 @@
 description: Bridge two unrelated domains using your vault's link graph - forces creative friction to spark new ideas
 category: thinking
 triggers_en: ["connect domains", "cross-pollinate", "bridge ideas", "find an unexpected link"]
+triggers_es: ["conecta estos dos temas", "cruza ideas de distintos mundos", "tiende un puente entre ideas", "busca una conexión inesperada"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-connect $ARGUMENTS`:

--- a/commands/obsidian-daily.md
+++ b/commands/obsidian-daily.md
@@ -2,6 +2,7 @@
 description: Create or update today's daily note - pulls calendar events, overdue tasks, and conversation context
 category: vault
 triggers_en: ["todays note", "create todays daily", "open daily", "today daily note"]
+triggers_es: ["nota de hoy", "crea la diaria de hoy", "abre mi diaria", "la nota diaria de hoy"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-daily`:

--- a/commands/obsidian-decide.md
+++ b/commands/obsidian-decide.md
@@ -2,6 +2,7 @@
 description: Record decisions - lightweight by default (logged to project notes), or a full ADR record with --formal
 category: thinking
 triggers_en: ["extract decisions", "log decisions", "what did we decide", "log this decision", "ADR", "record decision", "decision record"]
+triggers_es: ["saca las decisiones de esta conversación", "registra las decisiones", "¿qué decidimos?", "anota esta decisión", "ADR", "acta de decisión formal"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-decide $ARGUMENTS`:

--- a/commands/obsidian-distill.md
+++ b/commands/obsidian-distill.md
@@ -2,6 +2,7 @@
 description: Condense a long note or source into key claims, each tagged with provenance back to the exact source block it came from
 category: thinking
 triggers_en: ["distill this", "condense this note", "summarize with sources", "distill this source", "boil this down with provenance"]
+triggers_es: ["destila esto", "condensa esta nota", "resúmelo con fuentes", "destila esta fuente", "resume esto sin perder la trazabilidad"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-distill $ARGUMENTS`:

--- a/commands/obsidian-emerge.md
+++ b/commands/obsidian-emerge.md
@@ -2,6 +2,7 @@
 description: Surface unnamed patterns from your recent notes - recurring themes, hidden connections, and conclusions you haven't explicitly stated
 category: thinking
 triggers_en: ["find patterns", "what is emerging", "surface themes", "unnamed patterns"]
+triggers_es: ["busca patrones", "qué está emergiendo", "saca a la luz los temas recurrentes", "patrones que no he nombrado"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-emerge $ARGUMENTS`:

--- a/commands/obsidian-export.md
+++ b/commands/obsidian-export.md
@@ -2,6 +2,7 @@
 description: Export a clean structured snapshot of the vault that any agent or tool can consume - flat JSON, markdown index, or an OKF (Open Knowledge Format) bundle
 category: meta
 triggers_en: ["export vault", "snapshot vault", "dump vault", "vault export"]
+triggers_es: ["exporta el vault", "haz una foto del vault", "vuelca el vault", "exportación del vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-export $ARGUMENTS`:

--- a/commands/obsidian-find.md
+++ b/commands/obsidian-find.md
@@ -2,6 +2,7 @@
 description: Smart vault search - returns results with context, not just filenames
 category: vault
 triggers_en: ["find in vault", "search my notes", "where is", "what did I write about"]
+triggers_es: ["busca en el vault", "busca en mis notas", "dónde está", "qué escribí sobre"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-find $ARGUMENTS`:

--- a/commands/obsidian-graduate.md
+++ b/commands/obsidian-graduate.md
@@ -2,6 +2,7 @@
 description: Promote an idea fragment into a full project spec with tasks, board entries, and structure
 category: thinking
 triggers_en: ["promote idea", "graduate this to project", "make a project from this", "elevate idea"]
+triggers_es: ["promociona esta idea", "convierte esto en proyecto", "haz un proyecto de esto", "eleva esta idea"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-graduate $ARGUMENTS`:

--- a/commands/obsidian-health.md
+++ b/commands/obsidian-health.md
@@ -2,6 +2,7 @@
 description: Run a vault health check - grouped by severity, detects contradictions, concept gaps, stale claims, and structural issues
 category: meta
 triggers_en: ["vault health", "check vault", "audit vault", "vault diagnostics"]
+triggers_es: ["salud del vault", "revisa el vault", "audita el vault", "diagnóstico del vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-health`:

--- a/commands/obsidian-ingest.md
+++ b/commands/obsidian-ingest.md
@@ -2,6 +2,7 @@
 description: Ingest a source into the vault - the vault rewrites itself around new knowledge. Every ingest updates entities, rewrites stale claims, synthesizes new concepts, and resolves contradictions.
 category: research
 triggers_en: ["ingest this source", "add this article", "import this", "absorb this"]
+triggers_es: ["haz una ingesta de esta fuente", "añade este artículo", "importa esto", "absorbe esto"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-ingest $ARGUMENTS`:

--- a/commands/obsidian-init.md
+++ b/commands/obsidian-init.md
@@ -2,6 +2,7 @@
 description: Scan your vault and generate a _CLAUDE.md operating manual, index.md catalog, and log.md pointer
 category: meta
 triggers_en: ["init vault", "bootstrap vault", "setup vault", "scan vault"]
+triggers_es: ["inicializa el vault", "arranca el vault", "configura el vault", "escanea el vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-init`:

--- a/commands/obsidian-learn.md
+++ b/commands/obsidian-learn.md
@@ -2,6 +2,7 @@
 description: Review vault learnings, prune stale ones, surface active patterns - the vault's lessons compound or expire
 category: thinking
 triggers_en: ["review learnings", "what have I learned", "show lessons", "prune learnings"]
+triggers_es: ["revisa los aprendizajes", "qué he aprendido", "muéstrame las lecciones", "poda los aprendizajes"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-learn $ARGUMENTS`:

--- a/commands/obsidian-log.md
+++ b/commands/obsidian-log.md
@@ -2,6 +2,7 @@
 description: Log this work or dev session to the vault - infers project from context
 category: vault
 triggers_en: ["log this work", "log this session", "log this dev session", "obsidian log"]
+triggers_es: ["registra este trabajo", "registra esta sesión", "registra esta sesión de desarrollo", "obsidian log"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-log`:

--- a/commands/obsidian-panel.md
+++ b/commands/obsidian-panel.md
@@ -2,6 +2,7 @@
 description: Convene a panel of distinct perspectives on a decision - one independent verdict per lens, then a synthesis. A multi-persona complement to /obsidian-challenge
 category: thinking
 triggers_en: ["convene a panel", "advisor panel", "get multiple perspectives on", "panel review", "what would the experts say about"]
+triggers_es: ["convoca un panel", "panel de asesores", "dame varias perspectivas sobre esto", "revisión en panel", "qué dirían los expertos sobre esto"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-panel [decision or question]`:

--- a/commands/obsidian-person.md
+++ b/commands/obsidian-person.md
@@ -2,6 +2,7 @@
 description: Create or update a person note from conversation context
 category: vault
 triggers_en: ["save this person", "add person", "new contact note", "create person note"]
+triggers_es: ["guarda a esta persona", "añade una persona", "nueva nota de contacto", "crea una nota de persona"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-person $ARGUMENTS`:

--- a/commands/obsidian-project.md
+++ b/commands/obsidian-project.md
@@ -2,6 +2,7 @@
 description: Create or update a project note - adds to board and daily note automatically
 category: vault
 triggers_en: ["new project", "create project note", "project setup", "start a project"]
+triggers_es: ["nuevo proyecto", "crea una nota de proyecto", "configura el proyecto", "arranca un proyecto"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-project $ARGUMENTS`:

--- a/commands/obsidian-projects.md
+++ b/commands/obsidian-projects.md
@@ -2,6 +2,7 @@
 description: Live project status from git + local docs - infers all context from vault notes, no config required
 category: vault
 triggers_en: ["projects overview", "project status", "what am I working on", "show projects"]
+triggers_es: ["resumen de proyectos", "estado de los proyectos", "en qué estoy trabajando", "muéstrame los proyectos"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-projects $ARGUMENTS`:

--- a/commands/obsidian-recap.md
+++ b/commands/obsidian-recap.md
@@ -2,6 +2,7 @@
 description: Summarize a time period from the vault - today, week, or month
 category: vault
 triggers_en: ["recap today", "recap the week", "summarize the week", "month recap"]
+triggers_es: ["resumen de hoy", "resumen de la semana", "resume la semana", "resumen del mes"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-recap $ARGUMENTS`:

--- a/commands/obsidian-reconcile.md
+++ b/commands/obsidian-reconcile.md
@@ -2,6 +2,7 @@
 description: Find and resolve contradictions in the vault - the vault maintains its own truth
 category: thinking
 triggers_en: ["find contradictions", "reconcile vault", "fix conflicts", "vault contradictions"]
+triggers_es: ["busca contradicciones", "concilia el vault", "resuelve los conflictos", "contradicciones en el vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-reconcile $ARGUMENTS`:

--- a/commands/obsidian-recurring.md
+++ b/commands/obsidian-recurring.md
@@ -2,6 +2,7 @@
 description: Track a recurring obligation (payment, filing, ops) with a cadence and a computed next-due date
 category: vault
 triggers_en: ["recurring task", "monthly obligation", "remind me every month", "recurring payment", "track a recurring"]
+triggers_es: ["tarea recurrente", "obligación mensual", "recuérdamelo cada mes", "pago recurrente", "haz seguimiento de algo recurrente"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-recurring $ARGUMENTS`:

--- a/commands/obsidian-retrieval-eval.md
+++ b/commands/obsidian-retrieval-eval.md
@@ -2,6 +2,7 @@
 description: Measure how well vault search finds the right note for a natural-language question - recall@k and MRR, with the concrete failures
 category: meta
 triggers_en: ["evaluate retrieval", "how good is my vault search", "retrieval eval", "test vault search quality", "measure find quality"]
+triggers_es: ["evalúa la búsqueda", "qué tal funciona la búsqueda de mi vault", "evaluación de recuperación", "prueba la calidad de la búsqueda", "comprueba si encuentra bien mis notas"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-retrieval-eval $ARGUMENTS`:

--- a/commands/obsidian-review.md
+++ b/commands/obsidian-review.md
@@ -2,6 +2,7 @@
 description: Generate a structured weekly or monthly review note from vault history
 category: thinking
 triggers_en: ["weekly review", "monthly review", "review my week", "review my month"]
+triggers_es: ["revisión semanal", "revisión mensual", "revisa mi semana", "revisa mi mes"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-review $ARGUMENTS`:

--- a/commands/obsidian-save.md
+++ b/commands/obsidian-save.md
@@ -2,6 +2,7 @@
 description: Save everything worth keeping from this conversation to the vault
 category: vault
 triggers_en: ["save this", "save the conversation", "save to vault", "obsidian save"]
+triggers_es: ["guarda esto", "guarda la conversación", "guarda al vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-save`:

--- a/commands/obsidian-synthesize.md
+++ b/commands/obsidian-synthesize.md
@@ -2,6 +2,7 @@
 description: Automatic synthesis - scans the vault for unnamed patterns and writes synthesis pages without being asked
 category: thinking
 triggers_en: ["synthesize", "auto-synthesis", "make synthesis notes", "find unnamed patterns"]
+triggers_es: ["sintetiza", "síntesis automática", "crea notas de síntesis", "busca patrones sin nombrar"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-synthesize`:

--- a/commands/obsidian-task.md
+++ b/commands/obsidian-task.md
@@ -2,6 +2,7 @@
 description: Add a task to the right kanban board with inferred priority and due date
 category: vault
 triggers_en: ["add task", "new todo", "track this", "remind me"]
+triggers_es: ["añade una tarea", "nuevo pendiente", "haz seguimiento de esto", "recuérdamelo"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-task $ARGUMENTS`:

--- a/commands/obsidian-visualize.md
+++ b/commands/obsidian-visualize.md
@@ -2,6 +2,7 @@
 description: Generate a visual canvas map of your vault - see the shape of your second brain and how knowledge connects
 category: meta
 triggers_en: ["visualize vault", "vault map", "canvas of vault", "show me the vault shape"]
+triggers_es: ["visualiza el vault", "mapa del vault", "canvas del vault", "muéstrame la forma de mi vault"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-visualize $ARGUMENTS`:

--- a/commands/obsidian-world.md
+++ b/commands/obsidian-world.md
@@ -2,6 +2,7 @@
 description: Load your identity, values, priorities, and current state in one shot - with progressive context levels to avoid burning tokens
 category: vault
 triggers_en: ["load context", "what is going on", "where am I", "load my world"]
+triggers_es: ["carga el contexto", "qué está pasando", "dónde estoy", "carga mi mundo"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/obsidian-world`:

--- a/commands/podcast.md
+++ b/commands/podcast.md
@@ -2,6 +2,7 @@
 description: Extract metadata, transcript, and summary from a podcast episode, saved as an AI-first note in the vault
 category: research
 triggers_en: ["summarize this podcast", "podcast episode summary", "extract podcast", "what's in this episode"]
+triggers_es: ["resume este pódcast", "resumen del episodio", "extrae este pódcast", "qué dice este episodio"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/podcast [url]`:

--- a/commands/research-deep.md
+++ b/commands/research-deep.md
@@ -2,6 +2,7 @@
 description: Vault-first deep research - scans the vault, fills gaps (Perplexity + Grok when keyed, free key-less sources otherwise), synthesizes a delta, then propagates updates across people/projects/ideas via /obsidian-save
 category: research
 triggers_en: ["deep research", "thorough research", "vault-first research", "research gaps"]
+triggers_es: ["investigación profunda", "investiga a fondo", "investigación basada en mi vault", "rellena los huecos de información"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/research-deep [topic]`:

--- a/commands/research.md
+++ b/commands/research.md
@@ -2,6 +2,7 @@
 description: Web research with citations - Perplexity Sonar when an API key is set, free key-less sources (Wikipedia, HackerNews, arXiv, Reddit, and more) otherwise. Deep dossier with summary, facts, timeline, players, contrarian views, open questions
 category: research
 triggers_en: ["research this", "look up", "find information about", "perplexity research"]
+triggers_es: ["investiga esto", "búscalo", "busca información sobre", "investigación con perplexity"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/research [topic]`:

--- a/commands/vault-deep-synthesis.md
+++ b/commands/vault-deep-synthesis.md
@@ -2,6 +2,7 @@
 description: Deep cross-reference of everything the vault knows about one topic - agreements, contradictions, stale claims, and coverage gaps. Pure vault, no network
 category: thinking
 triggers_en: ["synthesize what I know about", "deep synthesis on", "cross-reference my notes on", "what does my vault say about"]
+triggers_es: ["sintetiza lo que sé sobre", "síntesis profunda sobre", "cruza mis notas sobre", "qué dice mi vault sobre"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/vault-deep-synthesis [topic]`:

--- a/commands/x-pulse.md
+++ b/commands/x-pulse.md
@@ -2,6 +2,7 @@
 description: Scan X for what's trending in a topic - themes, voices, hooks, and post ideas powered by Grok + Live Search
 category: research
 triggers_en: ["x pulse", "what is trending on twitter", "scan x for", "twitter pulse"]
+triggers_es: ["x pulse", "qué es tendencia en twitter", "escanea x en busca de", "pulso de twitter"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/x-pulse [topic]`:

--- a/commands/x-read.md
+++ b/commands/x-read.md
@@ -2,6 +2,7 @@
 description: Deep-read an X (Twitter) post via Grok + Live Search - verbatim post, thread, TL;DR, claims, reply sentiment, voices to watch
 category: research
 triggers_en: ["read this x post", "deep read this tweet", "analyze this tweet", "read this thread"]
+triggers_es: ["léeme este post de x", "profundiza en este tweet", "analiza este tweet", "léeme este hilo"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/x-read [url]`:

--- a/commands/youtube.md
+++ b/commands/youtube.md
@@ -2,6 +2,7 @@
 description: Extract transcript, metadata, and top comments from a YouTube video - summarized via Grok and saved to vault. Add --visual to also read the video's frames (scene detection)
 category: research
 triggers_en: ["summarize youtube", "youtube transcript", "extract video", "youtube to vault", "watch this video", "what's on screen in this video"]
+triggers_es: ["resume este vídeo de youtube", "transcripción de youtube", "extrae este vídeo", "youtube al vault", "mira este vídeo", "qué se ve en este vídeo"]
 ---
 
 Use the obsidian-second-brain skill. Execute `/youtube [url] [--visual]`:


### PR DESCRIPTION
Adds `triggers_es:` lines to all 44 command files - one language at a time, full coverage, as requested in CONTRIBUTING.md's translation guide.

Choices made:

- Natural conversational phrases a Spanish speaker would actually say to an assistant (Peninsular register), not literal word-for-word translations. Written and reviewed by a native speaker.
- Kept the "vault" loanword, following the CONTRIBUTING.md example ("guarda al vault").
- Invocation-style names (x pulse, notebooklm, ADR, obsidian log) left recognizable rather than force-translated.
- Redundant English variants collapsed where their Spanish equivalents would duplicate each other (e.g. obsidian-calendar 17 -> 13 phrases, with all four modes still represented).

Verification: `uv run pytest -q` passes (30/30). The diff touches frontmatter only: 44 files, +1 line each.
