### PR TITLE
Audit tail: three blind spots runtime-tested, one real bug fixed

### DIFF
--- a/hooks/obsidian-bg-agent.sh
+++ b/hooks/obsidian-bg-agent.sh
@@ -70,14 +70,16 @@ INSTRUCTIONS:
    - Ideas, learnings, or insights
    - Shoutouts or mentions worth logging
 3. Before creating any note, search for an existing one. Never duplicate.
-4. Update or create notes as appropriate:
-   - People: update People/Name.md interaction log; create a stub if missing
+4. Update or create notes as appropriate. Resolve every folder from _CLAUDE.md's
+   Folder Map (wiki-style wiki/entities|projects|logs|daily, Obsidian-style
+   People/|Projects/|Dev Logs/|Daily/ - use whichever layout the vault has):
+   - People: update the person's note interaction log; create a stub if missing
    - Projects: update status, Recent Activity, Key Decisions sections
-   - Dev work: create or update Dev Logs/YYYY-MM-DD - Project.md; link from project note
-   - Tasks: add to the right Boards/ kanban column (use TODAY date from above)
-   - Ideas: save to Ideas/ folder
+   - Dev work: create or update the dev log YYYY-MM-DD - Project.md; link from project note
+   - Tasks: add to the right kanban board column (use TODAY date from above)
+   - Ideas: save to the ideas/concepts folder
    - Decisions: append to the relevant project note's Key Decisions section
-5. Update today's daily note (Daily/[TODAY].md using the TODAY value above):
+5. Update today's daily note ([TODAY].md in the resolved daily folder):
    - Create it from the Daily Note template if it does not exist
    - Link everything you touched - people, projects, dev logs, decisions
 6. Propagate everywhere:

--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -222,8 +222,22 @@ def find_note(folder, name):
     return None
 
 
+def _folder(kind):
+    """Resolve a folder per references/folder-map.md instead of hardcoding
+    wiki-style: an Obsidian-style vault (the default bootstrap) would otherwise
+    get a parallel wiki/ tree forked into it. Rule: wiki/ at the root wins;
+    else the Obsidian-style folder if it exists; else the wiki default."""
+    wiki = {"daily": "wiki/daily", "entities": "wiki/entities", "projects": "wiki/projects"}[kind]
+    obs = {"daily": "Daily", "entities": "People", "projects": "Projects"}[kind]
+    if (VAULT / "wiki").is_dir():
+        return wiki
+    if (VAULT / obs).is_dir():
+        return obs
+    return wiki
+
+
 def daily_note(when):
-    return VAULT / "wiki" / "daily" / f"{when.strftime('%Y-%m-%d')}.md"
+    return VAULT / _folder("daily") / f"{when.strftime('%Y-%m-%d')}.md"
 
 
 def resolve_target(target, when):
@@ -232,15 +246,15 @@ def resolve_target(target, when):
     t = (target or "daily").strip()
     low = t.lower()
     if low.startswith("person:"):
-        p = find_note("wiki/entities", t.split(":", 1)[1])
+        p = find_note(_folder("entities"), t.split(":", 1)[1])
         if p:
             return p, p.stem, False
     elif low.startswith("project:"):
-        p = find_note("wiki/projects", t.split(":", 1)[1])
+        p = find_note(_folder("projects"), t.split(":", 1)[1])
         if p:
             return p, p.stem, False
     elif low == "finance":
-        p = find_note("wiki/projects", "Personal Finance")
+        p = find_note(_folder("projects"), "Personal Finance")
         if p:
             return p, p.stem, False
     return daily_note(when), "today's note", (low not in ("daily", "idea"))

--- a/tests/test_bg_agent_hook.py
+++ b/tests/test_bg_agent_hook.py
@@ -1,0 +1,85 @@
+"""Runtime tests for the PostCompact background agent hook.
+
+The audit's completeness critic flagged this as the highest-risk untested
+surface: it writes to the vault UNATTENDED with permissions skipped. These
+tests exercise the real script end-to-end - gates, stdin parsing, transcript
+extraction, prompt construction, and the spawn - against a stub `claude`
+binary, so nothing real is ever written.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "hooks" / "obsidian-bg-agent.sh"
+
+
+def _run_hook(stdin: str, env_extra: dict, tmp_path: Path) -> subprocess.CompletedProcess:
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir(exist_ok=True)
+    record = tmp_path / "claude-invocation.txt"
+    stub = stub_dir / "claude"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'{{ echo "CWD=$PWD"; printf \'ARG=%s\\n\' "$@"; }} > "{record}"\n',
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}", **env_extra}
+    env.pop("OBSIDIAN_VAULT_PATH", None)
+    env.pop("OBSIDIAN_BG_AGENT_ENABLED", None)
+    env.update(env_extra)
+    return subprocess.run(["bash", str(HOOK)], input=stdin, env=env,
+                          capture_output=True, text=True, timeout=30)
+
+
+def test_inert_without_vault_path(tmp_path):
+    r = _run_hook("{}", {}, tmp_path)
+    assert r.returncode == 0
+    assert not (tmp_path / "claude-invocation.txt").exists()
+
+
+def test_inert_without_enable_flag(tmp_path):
+    vault = tmp_path / "vault"; vault.mkdir()
+    r = _run_hook("{}", {"OBSIDIAN_VAULT_PATH": str(vault)}, tmp_path)
+    assert r.returncode == 0
+    assert not (tmp_path / "claude-invocation.txt").exists()
+
+
+def test_garbage_stdin_exits_clean(tmp_path):
+    vault = tmp_path / "vault"; vault.mkdir()
+    r = _run_hook("this is not json{{", {
+        "OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1",
+    }, tmp_path)
+    assert r.returncode == 0
+    assert not (tmp_path / "claude-invocation.txt").exists()
+
+
+def test_full_chain_spawns_agent_with_summary(tmp_path):
+    vault = tmp_path / "vault"; vault.mkdir()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "user", "message": {"content": "noise"}}) + "\n" +
+        json.dumps({"isCompactSummary": True,
+                    "message": {"content": "SUMMARY-SENTINEL: shipped the widget,\nmet a new person"}}) + "\n",
+        encoding="utf-8",
+    )
+    r = _run_hook(json.dumps({"transcript_path": str(transcript)}), {
+        "OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1",
+    }, tmp_path)
+    assert r.returncode == 0
+    record = tmp_path / "claude-invocation.txt"
+    for _ in range(50):  # the spawn is async by design
+        if record.exists() and record.read_text(encoding="utf-8").strip():
+            break
+        time.sleep(0.1)
+    body = record.read_text(encoding="utf-8")
+    assert f"CWD={vault}" in body, "agent must run inside the vault"
+    assert "ARG=--dangerously-skip-permissions" in body
+    assert "SUMMARY-SENTINEL" in body, "the compact summary must reach the prompt"
+    assert "met a new person" in body, "multi-line summaries must survive the base64 hop"

--- a/tests/test_telegram_ingest.py
+++ b/tests/test_telegram_ingest.py
@@ -1,0 +1,61 @@
+"""Runtime tests for the Telegram journal ingest's vault-write core.
+
+The audit's completeness critic flagged this surface as never runtime-tested.
+Driving it live against scratch vaults found a real bug: the bot hardcoded
+wiki-style folders (the class #117 swept from commands, but the Python
+integration was never covered), so an Obsidian-style vault would get a
+parallel wiki/ tree forked into it.
+"""
+
+from __future__ import annotations
+
+import datetime
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "integrations" / "telegram-journal"))
+
+import telegram_journal as tj  # noqa: E402
+
+WHEN = datetime.datetime(2026, 7, 11, 14, 30)
+
+
+def test_wiki_style_vault_routes_to_wiki_daily(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "wiki").mkdir(parents=True)
+    monkeypatch.setattr(tj, "VAULT", vault)
+    assert tj.daily_note(WHEN) == vault / "wiki/daily" / "2026-07-11.md"
+
+
+def test_obsidian_style_vault_routes_to_Daily(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "Daily").mkdir(parents=True)
+    (vault / "People").mkdir()
+    monkeypatch.setattr(tj, "VAULT", vault)
+    assert tj.daily_note(WHEN) == vault / "Daily" / "2026-07-11.md"
+    assert tj._folder("entities") == "People"
+
+
+def test_append_under_never_duplicates_headers(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "Daily").mkdir(parents=True)
+    monkeypatch.setattr(tj, "VAULT", vault)
+    note = tj.daily_note(WHEN)
+    tj.ensure_daily(note, WHEN)
+    tj.append_under(note, "## Journal", "- 14:30 first entry", WHEN)
+    tj.append_under(note, "## Journal", "- 14:31 second entry", WHEN)
+    body = note.read_text(encoding="utf-8")
+    assert "first entry" in body and "second entry" in body
+    assert body.count("## Journal") == 1
+
+
+def test_remove_block_supports_the_move_flow(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "Daily").mkdir(parents=True)
+    monkeypatch.setattr(tj, "VAULT", vault)
+    note = tj.daily_note(WHEN)
+    tj.ensure_daily(note, WHEN)
+    tj.append_under(note, "## Journal", "- 14:30 movable entry", WHEN)
+    tj.remove_block(note, "- 14:30 movable entry")
+    assert "movable entry" not in note.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

The original audit's completeness critic flagged three shipped surfaces that had never been runtime-tested. Before publishing the v0.12.0 release that says "we stress-tested everything", we tested them.

## Results

1. **bg-agent hook (highest risk - writes unattended): CLEAN.** Gates (double opt-in), garbage stdin, and the full parse-and-spawn chain exercised against a stub `claude` binary: the compact summary survives the base64 hop, the agent runs inside the vault with the right flags, and it stays inert without both env flags. 4 new tests. Its embedded prompt now resolves folders per the folder map instead of hardcoding one layout.
2. **MCP write path: CLEAN.** `live_test.py` (never run before) executed end-to-end against a scratch vault: handshake, all 10 tools, save-to-Inbox verified on disk. Path-traversal probes against save/update/read all correctly refused (`path is outside the vault`; save slugs titles).
3. **Telegram ingest: one REAL bug, fixed.** Driving the vault-write core live caught the bot hardcoding wiki-style folders (`wiki/daily`, `wiki/entities`, `wiki/projects`) - the exact class #117 swept from 18 commands, but the Python integration was never covered. On a default-bootstrapped Obsidian-style vault it would fork a parallel `wiki/` tree. Now resolves per the folder map (4 layout-sensitive tests). Header-safe appends, routing, and the /move flow verified healthy.

## Market tail (the two agents that died mid-audit, re-run inline)

Repo metadata is already strong (20 topics, good description, homepage), the issue queue is at **zero open**, and the project is present in the awesome-claude-code flow and on awesomeskills.dev - the audit's distribution-gap findings are stale. Remaining growth items (demo media, marketplace-style installs, phone access) are Phase E decisions, not defects.

## Tests

Full suite: **129 passed** (119 + 8 runtime tests + dist fence + assertions).

This closes the final open findings of the 175. The audit is fully resolved or explicitly deferred to Phase E decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)