### PR TITLE
Native Claude Code plugin-marketplace install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "obsidian-second-brain",
+  "owner": {
+    "name": "Eugeniu Ghelbur",
+    "email": "e.ghelbur@gmail.com"
+  },
+  "metadata": {
+    "description": "Marketplace for the obsidian-second-brain Claude Code plugin",
+    "version": "0.12.0"
+  },
+  "plugins": [
+    {
+      "name": "obsidian-second-brain",
+      "source": "./",
+      "description": "Operate any Obsidian vault as a living, AI-first second brain: 44 slash commands across vault management, thinking tools, a research toolkit, and scheduled agents.",
+      "version": "0.12.0",
+      "author": {
+        "name": "Eugeniu Ghelbur",
+        "email": "e.ghelbur@gmail.com"
+      },
+      "homepage": "https://github.com/eugeniughelbur/obsidian-second-brain",
+      "license": "MIT",
+      "category": "productivity",
+      "keywords": ["obsidian", "second-brain", "knowledge-management", "notes", "research"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "obsidian-second-brain",
+  "description": "Operate any Obsidian vault as a living, AI-first second brain: 44 slash commands across vault management, thinking tools, a research toolkit, and scheduled agents.",
+  "version": "0.12.0",
+  "author": {
+    "name": "Eugeniu Ghelbur",
+    "email": "e.ghelbur@gmail.com"
+  },
+  "homepage": "https://github.com/eugeniughelbur/obsidian-second-brain",
+  "license": "MIT",
+  "commands": "./commands/",
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": {
+    "obsidian-second-brain": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp",
+        "python",
+        "${CLAUDE_PLUGIN_ROOT}/integrations/obsidian-mcp-server/server.py"
+      ]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Native Claude Code plugin-marketplace install.** The repo is now its own plugin marketplace: `/plugin marketplace add eugeniughelbur/obsidian-second-brain` + `/plugin install obsidian-second-brain@obsidian-second-brain` replaces the clone-and-symlink dance for Claude Code users. The plugin ships all 44 commands (auto-discovered as skills, ~2k always-on tokens), the skill manual, the SessionStart context hook, the PostCompact background agent (still inert without `OBSIDIAN_BG_AGENT_ENABLED=1` - the hard gate is in the script), and the bundled vault MCP server (inline `mcpServers` in `plugin.json`, since `${CLAUDE_PLUGIN_ROOT}` does not expand in a root `.mcp.json`). Verified with a live local install: marketplace add, plugin install, 45 skills + 2 hooks in the inventory, and the MCP server connecting end-to-end. The classic `install.sh`/`setup.sh` path is unchanged and coexists. Fenced in CI by `tests/test_plugin_manifest.py` (manifests parse, versions sync with pyproject, referenced scripts exist, the bg-agent keeps its gate). This closes the audit's top distribution finding ("high-friction install vs one-click marketplace" - the single biggest stars gap).
+
 ## [0.12.0] - 2026-07-11 - The Stress Test
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ If you change an adapter's output layout, update the matching assertion in `test
 
 1. PRs land on `main` only when CI is green and the AI-first rule is upheld.
 2. Move "Unreleased" entries in `CHANGELOG.md` under a new version header with the release date.
-3. Bump version in `pyproject.toml` and `CITATION.cff`.
+3. Bump version in `pyproject.toml`, `CITATION.cff`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` (metadata + plugin entry; `tests/test_plugin_manifest.py` fails CI if these drift from pyproject).
 4. Tag and push: `git tag v0.X.0 && git push origin v0.X.0`.
 5. Cut a GitHub Release with notes copied from the CHANGELOG entry.
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,22 @@ vault/
 
 ### Claude Code (default)
 
-One line (clones the skill, installs the slash commands, offers the research env):
+**Native plugin install (recommended).** Inside any Claude Code session:
+
+```
+/plugin marketplace add eugeniughelbur/obsidian-second-brain
+/plugin install obsidian-second-brain@obsidian-second-brain
+```
+
+That ships all 44 commands, the skill manual, the session-context hook, the opt-in background agent (inert until you arm it - see [hooks/postcompact.hook.example.json](hooks/postcompact.hook.example.json)), and the vault MCP server. Then tell Claude where your vault lives by adding to the `env` section of `~/.claude/settings.json`:
+
+```json
+"env": { "OBSIDIAN_VAULT_PATH": "/path/to/your/vault" }
+```
+
+Restart Claude Code and run `/obsidian-init` inside your vault. Update later with `/plugin update obsidian-second-brain`.
+
+**Classic install (script).** One line (clones the skill, installs the slash commands, offers the research env):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/eugeniughelbur/obsidian-second-brain/main/scripts/quick-install.sh | bash

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/load_vault_context.py\""
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/obsidian-bg-agent.sh\"",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,0 +1,88 @@
+"""CI fence for the Claude Code plugin-marketplace distribution.
+
+The repo doubles as its own plugin marketplace: `.claude-plugin/marketplace.json`
+is the catalog, `.claude-plugin/plugin.json` the plugin manifest, and
+`hooks/hooks.json` the plugin hook wiring. These tests keep the three manifests
+parseable, mutually consistent, version-synced with pyproject.toml, and honest
+about the files they reference - so `/plugin install` never ships a broken tree.
+
+Verified against a live local install (marketplace add + install + `claude mcp
+list` shows the bundled server Connected) before this fence was written.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(relpath: str):
+    return json.loads((REPO_ROOT / relpath).read_text(encoding="utf-8"))
+
+
+def _pyproject_version() -> str:
+    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def test_plugin_manifest_parses_and_matches_pyproject_version():
+    plugin = _load(".claude-plugin/plugin.json")
+    assert plugin["name"] == "obsidian-second-brain"
+    assert plugin["version"] == _pyproject_version()
+
+
+def test_marketplace_catalog_agrees_with_plugin_manifest():
+    plugin = _load(".claude-plugin/plugin.json")
+    market = _load(".claude-plugin/marketplace.json")
+    assert market["name"] == "obsidian-second-brain"
+    entries = market["plugins"]
+    assert len(entries) == 1
+    entry = entries[0]
+    # The repo root is both the marketplace and its only plugin.
+    assert entry["source"] == "./"
+    assert entry["name"] == plugin["name"]
+    assert entry["version"] == plugin["version"]
+
+
+def test_plugin_manifest_paths_exist():
+    plugin = _load(".claude-plugin/plugin.json")
+    assert (REPO_ROOT / plugin["commands"]).is_dir()
+    assert (REPO_ROOT / plugin["hooks"]).is_file()
+    # Inline MCP server definition: the script it points at must exist.
+    # (Inline is the mechanism that works - a root .mcp.json expands
+    # ${CLAUDE_PLUGIN_ROOT} to empty, and would also register as a project
+    # MCP server for anyone opening this repo.)
+    servers = plugin["mcpServers"]
+    assert isinstance(servers, dict) and servers, "MCP server must be defined inline"
+    for server in servers.values():
+        for arg in server.get("args", []):
+            if "${CLAUDE_PLUGIN_ROOT}" in arg:
+                rel = arg.replace("${CLAUDE_PLUGIN_ROOT}/", "")
+                assert (REPO_ROOT / rel).is_file(), f"missing MCP file: {rel}"
+
+
+def test_plugin_hooks_reference_shipped_executable_scripts():
+    hooks = _load("hooks/hooks.json")["hooks"]
+    assert set(hooks) == {"SessionStart", "PostCompact"}
+    for event, groups in hooks.items():
+        for group in groups:
+            for hook in group["hooks"]:
+                paths = re.findall(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\"]+)", hook["command"])
+                assert paths, f"{event} hook must reference a plugin-rooted script"
+                for rel in paths:
+                    target = REPO_ROOT / rel
+                    assert target.is_file(), f"missing hook script: {rel}"
+    # The background agent writes unattended: it must keep its hard env gate so
+    # the plugin-shipped PostCompact wiring stays inert by default.
+    bg = (REPO_ROOT / "hooks/obsidian-bg-agent.sh").read_text(encoding="utf-8")
+    assert "OBSIDIAN_BG_AGENT_ENABLED" in bg
+
+
+def test_plugin_commands_cover_all_command_files():
+    plugin = _load(".claude-plugin/plugin.json")
+    commands_dir = REPO_ROOT / plugin["commands"]
+    assert len(list(commands_dir.glob("*.md"))) >= 40


### PR DESCRIPTION
## What

The repo becomes its own Claude Code plugin marketplace. Users install with:

```
/plugin marketplace add eugeniughelbur/obsidian-second-brain
/plugin install obsidian-second-brain@obsidian-second-brain
```

This closes the audit's top distribution finding: high-friction install (clone + install.sh + setup.sh + symlinks) vs the one-click marketplace installs rival tools ship.

## How

- `.claude-plugin/marketplace.json` - single-plugin catalog, the repo root is the plugin (`source: "./"`)
- `.claude-plugin/plugin.json` - commands dir, hooks file, and the MCP server defined **inline** (tested: a root `.mcp.json` expands `${CLAUDE_PLUGIN_ROOT}` to empty, and would double as a project MCP server for anyone opening this repo)
- `hooks/hooks.json` - SessionStart vault-context hook + PostCompact background agent, both plugin-rooted; the bg-agent keeps its hard `OBSIDIAN_BG_AGENT_ENABLED` gate so it ships inert
- README leads with the plugin path; the classic script path is unchanged and coexists
- Release process in CLAUDE.md gains the manifest version bump

## Verified

Live install in an isolated `CLAUDE_CONFIG_DIR`: marketplace add + plugin install succeed, `claude plugin details` shows 45 skills + 2 hooks (~2k always-on tokens), and `claude mcp list` shows the bundled vault server **Connected** via the plugin-rooted absolute path. `claude plugin validate` passes.

## Fenced

`tests/test_plugin_manifest.py` (5 tests): manifests parse, versions stay synced with pyproject.toml, every referenced script exists, and the bg-agent's env gate stays in place. Suite: 129 -> 134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)