### PR TITLE
hook: pass --strict-mcp-config to the headless propagation agent

### DIFF
--- a/hooks/obsidian-bg-agent.sh
+++ b/hooks/obsidian-bg-agent.sh
@@ -98,9 +98,17 @@ PROMPT=$(cat "$PROMPT_FILE")
 rm -f "$PROMPT_FILE"
 
 # Run headless agent in vault directory - async, logs to /tmp for debugging
+#
+# --strict-mcp-config: this agent uses filesystem tools only (see CONSTRAINTS in
+# the prompt above: "MCP is not available in this subprocess"). Without this flag
+# the headless run still loads every enabled MCP server, contradicting that stated
+# contract and wasting startup. Worse, for users running an MCP-based bot (e.g. a
+# Telegram/Slack integration) alongside Claude Code, this background run can seize
+# the bot's single MCP session and disrupt the live poller. The flag makes the
+# launch match the prompt's own contract.
 (
   cd "$VAULT" && \
-  claude --dangerously-skip-permissions -p "$PROMPT" >> /tmp/obsidian-bg-agent.log 2>&1
+  claude --dangerously-skip-permissions --strict-mcp-config -p "$PROMPT" >> /tmp/obsidian-bg-agent.log 2>&1
 ) &
 
 exit 0


### PR DESCRIPTION
## What

Pass `--strict-mcp-config` to the headless agent that `obsidian-bg-agent.sh`
launches for PostCompact vault propagation.

## Why

The agent's own prompt tells it, under CONSTRAINTS:

> Use filesystem tools only (Read, Write, Edit, Glob, Grep) — MCP is not
> available in this subprocess.

But the launch does not enforce that. A plain `claude -p` loads **every enabled
MCP server** in the user's config, contradicting the stated contract and adding
needless startup latency for servers the agent never uses.

It's also actively harmful in a common setup: users who run an **MCP-based bot**
(e.g. a Telegram or Slack integration) in another Claude Code session. Many such
bots poll a single long-lived MCP session; when this background PostCompact run
spins up the same MCP server, it can seize that session and disrupt the live
bot's poller. Adding `--strict-mcp-config` (with no `--mcp-config`) makes the
headless run load **zero** MCP servers — exactly what the prompt already
promises — so it's strictly safer and faster, with no behavior change for the
vault-writing itself (filesystem tools only).

## Change

One line in `hooks/obsidian-bg-agent.sh`:

```diff
-  claude --dangerously-skip-permissions -p "$PROMPT" >> /tmp/obsidian-bg-agent.log 2>&1
+  claude --dangerously-skip-permissions --strict-mcp-config -p "$PROMPT" >> /tmp/obsidian-bg-agent.log 2>&1
```

Verified: `claude --help` (2.1.211) documents the flag as "Only use MCP servers
from --mcp-config, ignoring all other MCP configurations".
