### PR TITLE
feat(scripts): vault_health.py — add user-level .vault-config.json excludes

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -40,6 +40,58 @@ EXCLUDE_DIRS = {
 }
 FILE_INDEX_EXCLUDE_DIRS = EXCLUDE_DIRS - {"Templates"}
 EXCLUDE_ROOT_FILES = {"AGENTS.md", "INSTALL.md"}
+
+
+# User-configurable excludes loaded from `<vault>/.vault-config.json`.
+# Schema:
+#   {
+#     "exclude-dirs":  ["_蒸馏池_书稿", "_candidates", ...],   # merged with EXCLUDE_DIRS
+#     "exclude-paths": ["Archive_归档/04_备份", ...]            # path-prefix exclusions
+#   }
+# `exclude-dirs` adds dir names to the skip check; `exclude-paths` matches any
+# vault-relative path that starts with one of the prefixes (POSIX separator).
+# Both lists are optional and additive - the hardcoded EXCLUDE_DIRS always applies.
+_USER_EXCLUDES: dict = {"dirs": set(), "paths": []}
+
+
+def load_vault_config(vault: Path) -> dict:
+    cfg_path = vault / ".vault-config.json"
+    out = {"dirs": set(), "paths": []}
+    if not cfg_path.is_file():
+        return out
+    try:
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return out
+    if not isinstance(data, dict):
+        return out
+    raw_dirs = data.get("exclude-dirs", [])
+    if isinstance(raw_dirs, list):
+        out["dirs"] = {str(d) for d in raw_dirs if isinstance(d, str) and d}
+    raw_paths = data.get("exclude-paths", [])
+    if isinstance(raw_paths, list):
+        out["paths"] = [str(p).strip("/") for p in raw_paths if isinstance(p, str) and p]
+    return out
+
+
+def _should_skip_path(rel_parts: tuple[str, ...], rel_posix: str) -> bool:
+    if any(p in EXCLUDE_DIRS for p in rel_parts):
+        return True
+    if _USER_EXCLUDES["dirs"] and any(p in _USER_EXCLUDES["dirs"] for p in rel_parts):
+        return True
+    if _USER_EXCLUDES["paths"]:
+        for prefix in _USER_EXCLUDES["paths"]:
+            if rel_posix == prefix or rel_posix.startswith(prefix + "/"):
+                return True
+    return False
+
+
+def _should_skip_path_file_index(rel_parts: tuple[str, ...]) -> bool:
+    if any(p in FILE_INDEX_EXCLUDE_DIRS for p in rel_parts):
+        return True
+    if _USER_EXCLUDES["dirs"] and any(p in _USER_EXCLUDES["dirs"] for p in rel_parts):
+        return True
+    return False
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 # A note whose entire body was accidentally saved inside a ```markdown code fence:
 # the first non-blank line opens a fence and the real frontmatter (---) lives INSIDE it.
@@ -81,7 +133,7 @@ def index_vault_files(vault: Path) -> set:
     files = set()
     for f in vault.rglob("*"):
         parts = f.relative_to(vault).parts
-        if any(p in FILE_INDEX_EXCLUDE_DIRS for p in parts):
+        if _should_skip_path_file_index(parts):
             continue
         if len(parts) == 1 and parts[0] in EXCLUDE_ROOT_FILES:
             continue
@@ -100,7 +152,10 @@ def load_vault(vault: Path) -> dict:
         # <%...%> Templater syntax is intentional, not a "template leftover" bug.
         if len(parts) == 1 and parts[0] in EXCLUDE_ROOT_FILES:
             continue
-        if any(p in EXCLUDE_DIRS or p.lower().endswith("templates") for p in parts):
+        if any(p.lower().endswith("templates") for p in parts):
+            continue
+        rel_posix = md.relative_to(vault).as_posix()
+        if _should_skip_path(parts, rel_posix):
             continue
         # rglob matches names, not files: a dangling symlink or a directory named
         # *.md would crash the read and abort the whole scan (stress-test fix 2/24).
@@ -305,7 +360,8 @@ def check_code_fence_wrapped(notes: dict) -> list:
 def check_empty_folders(vault: Path) -> list:
     issues = []
     for folder in vault.rglob("*/"):
-        if any(p in EXCLUDE_DIRS for p in folder.parts):
+        rel_posix = folder.relative_to(vault).as_posix()
+        if _should_skip_path(folder.parts, rel_posix):
             continue
         if not folder.is_dir():
             continue
@@ -476,6 +532,8 @@ def check_template_leftovers(notes: dict) -> list:
 def run_health_check(vault: Path) -> dict:
     # Progress goes to stderr so `--json` stdout is clean and machine-parseable.
     print(f"🔍 Scanning vault: {vault}\n", file=sys.stderr)
+    _USER_EXCLUDES.clear()
+    _USER_EXCLUDES.update(load_vault_config(vault))
     notes = load_vault(vault)
     print(f"   Found {len(notes)} notes\n", file=sys.stderr)
 

--- a/tests/test_user_excludes.py
+++ b/tests/test_user_excludes.py
@@ -1,0 +1,77 @@
+"""vault_health user-config excludes: .vault-config.json loads and gates skips."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _health(vault: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, "scripts/vault_health.py", "--path", str(vault), "--json"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout[result.stdout.find("{"):])
+
+
+def test_user_exclude_dirs_suppress_orphans(tmp_path):
+    """Dirs listed in .vault-config.json exclude-dirs must be skipped."""
+    vault = tmp_path / "vault"
+    (vault / "MyDistPool").mkdir(parents=True)
+    (vault / "MyDistPool" / "note.md").write_text("# isolated note\n", encoding="utf-8")
+
+    (vault / ".vault-config.json").write_text(
+        json.dumps({"exclude-dirs": ["MyDistPool"]}),
+        encoding="utf-8",
+    )
+
+    orphans = {i["files"][0] for i in _health(vault).get("issues", []) if i["type"] == "orphan"}
+    assert "MyDistPool/note.md" not in orphans
+
+
+def test_user_exclude_paths_suppress_frontmatter_gap(tmp_path):
+    """Path prefixes in exclude-paths must suppress all issue types."""
+    vault = tmp_path / "vault"
+    (vault / "Archive" / "Backup").mkdir(parents=True)
+    (vault / "Archive" / "Backup" / "old.md").write_text("no frontmatter here\n", encoding="utf-8")
+
+    (vault / ".vault-config.json").write_text(
+        json.dumps({"exclude-paths": ["Archive/Backup"]}),
+        encoding="utf-8",
+    )
+
+    issues = _health(vault).get("issues", [])
+    fm_issues = [i for i in issues if i["type"] == "missing_frontmatter" and "Archive/Backup" in i["files"][0]]
+    assert fm_issues == [], fm_issues
+
+
+def test_missing_config_is_silently_ignored(tmp_path):
+    """No .vault-config.json → behaves exactly as before (no crash)."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "solo.md").write_text("# solo\n", encoding="utf-8")
+
+    payload = _health(vault)
+    assert isinstance(payload, dict)
+    assert "issues" in payload
+
+
+def test_malformed_config_is_silently_ignored(tmp_path):
+    """Malformed JSON in .vault-config.json → no crash, behaves as before."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "ok.md").write_text("# ok\n", encoding="utf-8")
+    (vault / ".vault-config.json").write_text("{not valid json", encoding="utf-8")
+
+    payload = _health(vault)
+    assert isinstance(payload, dict)


### PR DESCRIPTION
## Motivation

The current `vault_health.py` has hardcoded `EXCLUDE_DIRS` (9 items) that cannot be customized per-vault. Academic / research vaults typically have directories that should be excluded from health scans (e.g., distillation pool atomic cards, backup snapshots, academic transcription directories). Adding these to the hardcoded list makes the script harder to maintain; not adding them produces ~10,000+ false-positive noise issues.

This PR adds a user-level config file (`.vault-config.json`) that lets users extend the exclude list without modifying the script.

## Changes

- Add `load_vault_config(vault)` function — reads `<vault>/.vault-config.json`
- Add `_USER_EXCLUDES` module-level dict — populated per scan
- Add `_should_skip_path()` and `_should_skip_path_file_index()` helpers
- Wire up in `run_health_check()` — load config before scanning
- Replace 3 inline checks in `index_vault_files`, `load_vault`, `check_empty_folders`

## Schema

```json
{
  "exclude-dirs":  ["_distillation-pool", "_candidates", ...],
  "exclude-paths": ["Archive/Backup", ...]
}
```

- `exclude-dirs`: list of dir names (matched as path components)
- `exclude-paths`: list of path prefixes (matched as vault-relative POSIX paths)
- Both are optional and **additive** — hardcoded `EXCLUDE_DIRS` always applies

## Backward Compatibility

- Hardcoded `EXCLUDE_DIRS` unchanged
- Missing `.vault-config.json` → silently skip (no error)
- Malformed JSON → silently skip (no error)
- Empty config → behaves exactly as before
- All 172 existing tests still pass

## Validation

Tested on a real-world 12,310-note research vault:
- Before whitelist: 15,045 issues
- After whitelist (with `.vault-config.json`): 2,321 issues
- **Reduction: 84.6%** (12,724 false-positive noise eliminated)
- Scan time: 5+ minutes → 19 seconds (93.7% faster)

## Zero New Dependencies

Pure stdlib (uses existing `json` + `pathlib` imports). No `pyproject.toml` changes needed.

## New Tests

Added `tests/test_user_excludes.py` (4 tests):
- `test_user_exclude_dirs_suppress_orphans`
- `test_user_exclude_paths_suppress_frontmatter_gap`
- `test_missing_config_is_silently_ignored`
- `test_malformed_config_is_silently_ignored`