### PR TITLE
Deprecate codex-cli/opencode builds; fix stale architecture.md adapter docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Deprecated
 
-- **The `codex-cli` and `opencode` per-platform builds are deprecated in favor of the unified `agent-skills` build (0.13.0).** Both emit into the same `.agents/skills/` layout the new build does, so they are redundant now that one spec-compliant tree serves Codex CLI, OpenCode, and Google Antigravity together and installs via `npx skills`. Their generated `INSTALL.md` now carries a deprecation banner pointing at `dist/agent-skills/INSTALL.md`; the builds still work and will be removed in a future release. `claude-code`, `gemini-cli`, `hermes`, and `pi` are unaffected.
+- **The `codex-cli` and `opencode` per-platform builds are deprecated in favor of the unified `agent-skills` build (0.13.0).** The `codex-cli` build emits into the same `.agents/skills/` layout the unified build covers, and OpenCode natively reads `.agents/skills/` directly (verified live: all 44 skills load from the unified tree with zero validation warnings), so both per-platform builds are redundant now that one spec-compliant tree serves Codex CLI, OpenCode, and Google Antigravity together and installs via `npx skills`. Their generated `INSTALL.md` now carries a deprecation banner pointing at `dist/agent-skills/INSTALL.md`; the builds still work and will be removed in a future release. `claude-code`, `gemini-cli`, `hermes`, and `pi` are unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - **`/youtube` summarizes via Gemini when `GEMINI_API_KEY` is set, with automatic Grok fallback.** New `lib/gemini.py` mirrors `grok.call`'s return shape (drop-in swap), retries with backoff, logs to the usage ledger, and sends the key in the `x-goog-api-key` header - never in the URL query string, so it cannot leak into access logs. `gemini-2.5-flash` default (generous free tier); no Gemini key means exactly the old Grok-only behavior.
   - **The health check no longer re-reports links echoed by logs and old reports.** Activity logs and prior health reports quote every broken link they mention without owning it, so the wanted-notes scan counted each finding once per echo. Notes matching `_CLAUDE.md`, `log.md`, or `Vault Health*` are now excluded from the outgoing-link audit by default (they still resolve as link targets and get every other check), and `.vault-config.json` gains an `exclude-link-scan` glob list for user extensions. Covered by `tests/test_user_excludes.py`.
 
+### Deprecated
+
+- **The `codex-cli` and `opencode` per-platform builds are deprecated in favor of the unified `agent-skills` build (0.13.0).** Both emit into the same `.agents/skills/` layout the new build does, so they are redundant now that one spec-compliant tree serves Codex CLI, OpenCode, and Google Antigravity together and installs via `npx skills`. Their generated `INSTALL.md` now carries a deprecation banner pointing at `dist/agent-skills/INSTALL.md`; the builds still work and will be removed in a future release. `claude-code`, `gemini-cli`, `hermes`, and `pi` are unaffected.
+
+### Fixed
+
+- **`architecture.md` still described the pre-agent-skills adapter set.** The adapter-pattern section said "the other five adapters (Codex CLI, Gemini CLI, OpenCode, Hermes, Pi) emit a dispatcher file ... with an auto-generated routing table" - which omitted `agent-skills` and misdescribed `codex-cli` and `hermes`, both of which emit native skills, not a routing-table dispatcher. Corrected the adapter description, the "command sets" count, and the repo-tree listing to include `agent-skills`. (`CLAUDE.md` was already updated upstream.)
+
 ## [0.13.0] - 2026-07-18 - The Open Standard
 
 ### Security

--- a/adapters/codex-cli/adapter.sh
+++ b/adapters/codex-cli/adapter.sh
@@ -151,6 +151,13 @@ _codex_emit_install_hint() {
   cat > "$dst/INSTALL.md" <<'EOF'
 # Install on Codex CLI
 
+> **Deprecated.** This per-platform build is superseded by the unified Agent
+> Skills build (`bash scripts/build.sh --platform agent-skills`), which emits
+> one spec-compliant `.agents/skills/` tree that Codex CLI, OpenCode, and
+> Google Antigravity all read, and installs via `npx skills`. This codex-cli
+> build still works but will be removed in a future release. See
+> `dist/agent-skills/INSTALL.md`.
+
 ```bash
 # From the repo root, after running `bash scripts/build.sh --platform codex-cli`:
 # Copy (or symlink) the built tree into your vault root:

--- a/adapters/opencode/adapter.sh
+++ b/adapters/opencode/adapter.sh
@@ -101,6 +101,13 @@ _opencode_emit_install_hint() {
   cat > "$dst/INSTALL.md" <<'EOF'
 # Install on OpenCode
 
+> **Deprecated.** This per-platform build is superseded by the unified Agent
+> Skills build (`bash scripts/build.sh --platform agent-skills`), which emits
+> one spec-compliant `.agents/skills/` tree that OpenCode, Codex CLI, and
+> Google Antigravity all read, and installs via `npx skills`. This opencode
+> build still works but will be removed in a future release. See
+> `dist/agent-skills/INSTALL.md`.
+
 ```bash
 # After running `bash scripts/build.sh --platform opencode`:
 cp -R dist/opencode/. /path/to/your/vault/

--- a/architecture.md
+++ b/architecture.md
@@ -22,11 +22,11 @@ The AI-first vault rule ties it all together: every note a command writes is des
 
 ## The adapter pattern (the core idea)
 
-`commands/` is the single source of truth. The build compiles it per platform instead of maintaining six command sets.
+`commands/` is the single source of truth. The build compiles it per platform instead of maintaining seven command sets.
 
 - `commands/<name>.md` uses Claude Code's slash-command shape and declares `description:`, `category:`, `triggers_en:`, and optional `exclude:` frontmatter.
 - `scripts/build.sh` orchestrates the `adapters/` layer. `bash scripts/build.sh` builds all platforms; `--platform <name>` builds one.
-- The **Claude Code adapter is an identity copy**. The other five adapters (Codex CLI, Gemini CLI, OpenCode, Hermes, Pi) emit a dispatcher file at the dist root (`AGENTS.md`, `GEMINI.md`, or the Pi/Hermes equivalent) with an auto-generated routing table built from each command's `description:`, grouped by `category:` then language, plus the command bodies under `.codex/commands/` (or `.gemini/`, `.opencode/`, `.pi/`, Hermes skills).
+- The **Claude Code adapter is an identity copy**. The other six adapters translate per platform: `codex-cli`, `hermes`, and `agent-skills` emit **native skills** (one `SKILL.md` per command; `agent-skills` is a single spec-compliant `.agents/skills/` tree that Codex CLI, OpenCode, and Google Antigravity all read, with a shared `obsidian-core` engine skill), `pi` emits a Pi package (`.pi/prompts/` + `.pi/skills/`), and `gemini-cli` / `opencode` emit a dispatcher file (`GEMINI.md` / `AGENTS.md`) with an auto-generated routing table built from each command's `description:`, grouped by `category:` then language, plus the command bodies under `.gemini/` / `.opencode/`.
 - Claude-specific wording is neutralized for the other CLIs (for example `Read tool` becomes `read files`).
 - Output lands in `dist/<platform>/`, which is gitignored and regenerated - never hand-edited.
 
@@ -56,7 +56,7 @@ obsidian-second-brain/
 |-- commands/            # 44 command .md files (the source)
 |-- references/          # ai-first-rules.md (canonical) + schemas + templates + bases/
 |-- scripts/             # build.sh, lib.sh, vault tooling, research/, architect_scan.py, ...
-|-- adapters/            # lib.sh + {claude-code,codex-cli,gemini-cli,opencode,hermes,pi}/adapter.sh
+|-- adapters/            # lib.sh + {claude-code,codex-cli,gemini-cli,opencode,hermes,pi,agent-skills}/adapter.sh
 |-- hooks/               # validate-ai-first.sh, load_vault_context.py, obsidian-bg-agent.sh
 |-- dist/                # build output per platform (gitignored)
 |-- tests/               # smoke tests + CI fixtures


### PR DESCRIPTION
Follow-up to #141. That PR landed the unified `agent-skills` build but deliberately deferred the deprecations and left one doc gap; this closes both. Scoped tight - four files, no overlap with #141.

## What this changes

- **Deprecation banners** on the `codex-cli` and `opencode` generated `INSTALL.md`. The `codex-cli` build emits into the same `.agents/skills/` layout the unified build covers, and OpenCode natively reads `.agents/skills/` directly (all 44 skills load from the unified tree with zero validation warnings), so both per-platform builds are redundant now that one spec-compliant tree serves Codex CLI, OpenCode, and Google Antigravity together (installable via `npx skills`). The banner points users at `dist/agent-skills/INSTALL.md`. The builds still work and will be removed in a future release; `claude-code`, `gemini-cli`, `hermes`, and `pi` are untouched.
- **`architecture.md` adapter-pattern fix.** It still read "the other five adapters (Codex CLI, Gemini CLI, OpenCode, Hermes, Pi) emit a dispatcher file ... with an auto-generated routing table" - which omitted `agent-skills` entirely and misdescribed `codex-cli` and `hermes`, both of which emit native skills, not a routing-table dispatcher. Corrected the adapter description, the "command sets" count (six -> seven), and the repo-tree listing. `CLAUDE.md` was already updated upstream, so it is intentionally left alone here.
- **CHANGELOG** entry under `Unreleased` (Deprecated + Fixed).

## Not in scope

No adapter behavior change, no removals - just the banner text and the doc correction. Removing the two deprecated adapters is a later PR once the unified build has a release under its belt.

## Verification

- `uv run pytest -q` -> **177 passed**.
- Deprecation banner present in built `dist/codex-cli/INSTALL.md` and `dist/opencode/INSTALL.md`.
- Diff is exactly four files: the two adapters, `architecture.md`, `CHANGELOG.md`.

Live discovery of the `agent-skills` build itself is confirmed on OpenCode 1.17.15 and the Antigravity CLI (headless `--add-dir` + interactive `/skills`) in the #141 thread.

