### PR TITLE
Fork gold round 2: Brave source, hardened usage ledger, Gemini youtube, link-scan excludes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ PERPLEXITY_API_KEY=
 # Get key: https://app.tavily.com
 TAVILY_API_KEY=
 
+# ─── Brave Search (optional) ────────────────────────────────
+# Extra web-search source for /research free mode - joins the key-less pool
+# when set, skipped silently when empty. Free tier: 2,000 queries/month.
+# Get key: https://brave.com/search/api
+BRAVE_API_KEY=
+
 # ─── Google Gemini ──────────────────────────────────────────
 # Powers /notebooklm (vault-grounded synthesis via Gemini File Search).
 # Get key (free tier available): https://aistudio.google.com/apikey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Fork gold, round 2 - four upgrades mined from the 2026-07-18 sweep of all 408 forks** (see `FORK_INSIGHTS.md` round 2; each idea credited to the fork that built it there):
+  - **Brave Search as an optional research source.** When `BRAVE_API_KEY` is set, Brave joins the `/research` free-mode pool (free tier: 2,000 queries/month as of 2026-07); without it the pool stays fully key-less. Same plain-requests + shared-cache shape as the Tavily source; the key travels in the `X-Subscription-Token` header.
+  - **The usage ledger now covers Perplexity, and can never break a paid call.** `usage.log_call` previously logged only Grok calls and would raise on an unwritable ledger path - failing the research call it was observing. It is now fail-soft by contract (warns on stderr, never raises), and every Perplexity call logs tokens plus an estimated cost (sonar/sonar-pro/sonar-deep-research rates as of 2026-07; unknown models log tokens with cost 0.0 rather than inventing a price). `/research` and `/research-deep` label their entries so per-command spend is auditable.
+  - **`/youtube` summarizes via Gemini when `GEMINI_API_KEY` is set, with automatic Grok fallback.** New `lib/gemini.py` mirrors `grok.call`'s return shape (drop-in swap), retries with backoff, logs to the usage ledger, and sends the key in the `x-goog-api-key` header - never in the URL query string, so it cannot leak into access logs. `gemini-2.5-flash` default (generous free tier); no Gemini key means exactly the old Grok-only behavior.
+  - **The health check no longer re-reports links echoed by logs and old reports.** Activity logs and prior health reports quote every broken link they mention without owning it, so the wanted-notes scan counted each finding once per echo. Notes matching `_CLAUDE.md`, `log.md`, or `Vault Health*` are now excluded from the outgoing-link audit by default (they still resolve as link targets and get every other check), and `.vault-config.json` gains an `exclude-link-scan` glob list for user extensions. Covered by `tests/test_user_excludes.py`.
+
 ## [0.13.0] - 2026-07-18 - The Open Standard
 
 ### Security

--- a/commands/research.md
+++ b/commands/research.md
@@ -13,7 +13,7 @@ Use the obsidian-second-brain skill. Execute `/research [topic]`:
    ```bash
    uv run --directory "SKILL_ROOT" -m scripts.research.research "<topic>"
    ```
-   The script auto-selects its mode: if `PERPLEXITY_API_KEY` is set it uses Perplexity Sonar (paid); otherwise it falls back to free, key-less sources. Pass `--free` to force free mode even when a key is set, or `--academic` (free mode only) to restrict to scholarly sources (arXiv, Semantic Scholar, OpenAlex, CrossRef). If `TAVILY_API_KEY` is set, Tavily joins the free-mode pool as an extra web source; without it the pool stays fully key-less - never require it.
+   The script auto-selects its mode: if `PERPLEXITY_API_KEY` is set it uses Perplexity Sonar (paid); otherwise it falls back to free, key-less sources. Pass `--free` to force free mode even when a key is set, or `--academic` (free mode only) to restrict to scholarly sources (arXiv, Semantic Scholar, OpenAlex, CrossRef). If `TAVILY_API_KEY` or `BRAVE_API_KEY` is set, that source joins the free-mode pool as an extra web source; without them the pool stays fully key-less - never require either.
 
 3. Handle the output by mode:
    - **Paid mode** - the script prints a finished dossier (Summary, Key Facts with recency markers, Timeline, Key Players, Contrarian Views, Further Reading, Open Questions, Sources) and saves the AI-first note itself to `Research/Web/` plus a log line. Show the dossier verbatim, then surface the saved file path. Nothing else to do.

--- a/commands/youtube.md
+++ b/commands/youtube.md
@@ -1,5 +1,5 @@
 ---
-description: Extract transcript, metadata, and top comments from a YouTube video - summarized via Grok and saved to vault. Add --visual to also read the video's frames (scene detection)
+description: Extract transcript, metadata, and top comments from a YouTube video - summarized via Gemini (free tier) or Grok and saved to vault. Add --visual to also read the video's frames (scene detection)
 category: research
 triggers_en: ["summarize youtube", "youtube transcript", "extract video", "youtube to vault", "watch this video", "what's on screen in this video"]
 triggers_es: ["resume este vídeo de youtube", "transcripción de youtube", "extrae este vídeo", "youtube al vault", "mira este vídeo", "qué se ve en este vídeo"]
@@ -21,7 +21,7 @@ Use the obsidian-second-brain skill. Execute `/youtube [url] [--visual]`:
 3. The script:
    - Extracts the transcript via `youtube-transcript-api` (free, no API key).
    - If `YOUTUBE_API_KEY` is set, also fetches title, channel, view/like counts, top comments. Otherwise skips metadata silently.
-   - Sends the transcript (and optional comments) to Grok for AI-first summarization.
+   - Sends the transcript (and optional comments) for AI-first summarization: Gemini (`gemini-2.5-flash`, generous free tier) when `GEMINI_API_KEY` is set, otherwise Grok; a Gemini failure falls back to Grok automatically.
    - Returns: TL;DR, Key Points, Notable Quotes, Themes & Topics, Comment Sentiment, Worth Following Up On.
    - With `--visual`: downloads the video (yt-dlp, <=720p) and extracts one frame per scene change (ffmpeg scene detection, not a fixed timer), so visual substance is captured. Hero frames are copied into the vault and embedded in the note; the full keyframe set is left on disk for you to read. Requires `yt-dlp` and `ffmpeg` on PATH (`brew install yt-dlp ffmpeg`). If either is missing or download fails, the visual layer is skipped with a warning and the transcript summary still saves.
 

--- a/scripts/research/lib/gemini.py
+++ b/scripts/research/lib/gemini.py
@@ -1,0 +1,84 @@
+"""Gemini text client for plain summarization calls (no grounding, no tools).
+
+The cheap summarizer: /youtube prefers this over Grok when GEMINI_API_KEY is
+set because gemini-2.5-flash has a generous free tier (as of 2026-07,
+ai.google.dev/pricing). Same return shape as grok.call so call sites can fall
+back transparently. Pattern from fork-insights round 2 (the api-ledger fork),
+with one hygiene change: the key travels in the x-goog-api-key header, never
+in the URL query string, so it cannot leak into access or proxy logs.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+from . import usage
+from .config import GEMINI_API_KEY, get_optional
+
+GEMINI_SUMMARY_MODEL = get_optional("GEMINI_SUMMARY_MODEL", "gemini-2.5-flash")
+API_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+MAX_RETRIES = 3
+BACKOFF_SECONDS = (1, 3, 8)
+
+
+def call(
+    prompt: str,
+    *,
+    command: str,
+    model: str | None = None,
+    max_output_tokens: int = 4000,
+) -> dict[str, Any]:
+    """Call Gemini generateContent. Returns {text, input_tokens, output_tokens,
+    cost_usd, raw} - the grok.call shape, so callers can swap providers."""
+    model = model or GEMINI_SUMMARY_MODEL
+    headers = {
+        "x-goog-api-key": GEMINI_API_KEY(),
+        "Content-Type": "application/json",
+    }
+    body = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"maxOutputTokens": max_output_tokens},
+    }
+
+    last_err: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            r = requests.post(API_URL.format(model=model), json=body, headers=headers, timeout=180)
+            if r.status_code == 200:
+                data = r.json()
+                parts = (data.get("candidates") or [{}])[0].get("content", {}).get("parts", [])
+                text = "".join(p.get("text", "") for p in parts).strip()
+                if not text:
+                    raise RuntimeError(f"Gemini returned no text (finishReason: "
+                                       f"{(data.get('candidates') or [{}])[0].get('finishReason')})")
+                u = data.get("usageMetadata") or {}
+                in_tok = int(u.get("promptTokenCount") or 0)
+                out_tok = int(u.get("candidatesTokenCount") or 0)
+                # Free tier by default; 0.0 is honest for the default model.
+                # If a paid tier/model is configured, the tokens are still logged.
+                cost = 0.0
+                usage.log_call(command, model, in_tok, out_tok, cost,
+                               extra={"provider": "gemini"})
+                return {
+                    "text": text,
+                    "input_tokens": in_tok,
+                    "output_tokens": out_tok,
+                    "cost_usd": cost,
+                    "raw": data,
+                }
+            if r.status_code in (429, 500, 502, 503, 504):
+                wait = BACKOFF_SECONDS[min(attempt, len(BACKOFF_SECONDS) - 1)]
+                print(f"[Gemini {r.status_code}, retrying in {wait}s...]")
+                time.sleep(wait)
+                continue
+            raise RuntimeError(f"Gemini API error {r.status_code}: {r.text[:500]}")
+        except requests.RequestException as e:
+            last_err = e
+            wait = BACKOFF_SECONDS[min(attempt, len(BACKOFF_SECONDS) - 1)]
+            print(f"[Gemini network error: {e}, retrying in {wait}s...]")
+            time.sleep(wait)
+
+    raise RuntimeError(f"Gemini API failed after {MAX_RETRIES} retries: {last_err}")

--- a/scripts/research/lib/perplexity.py
+++ b/scripts/research/lib/perplexity.py
@@ -5,6 +5,7 @@ import time
 import requests
 from typing import Any
 
+from . import usage
 from .config import PERPLEXITY_API_KEY, PERPLEXITY_RESEARCH_MODEL, PERPLEXITY_DEEP_MODEL
 
 API_URL = "https://api.perplexity.ai/chat/completions"
@@ -16,7 +17,7 @@ BACKOFF_SECONDS = (1, 3, 8)
 _THINK_BLOCK = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 
 
-def call(prompt: str, *, model: str | None = None, deep: bool = False, max_tokens: int = 4000) -> dict[str, Any]:
+def call(prompt: str, *, model: str | None = None, deep: bool = False, max_tokens: int = 4000, command: str = "research") -> dict[str, Any]:
     model = model or (PERPLEXITY_DEEP_MODEL if deep else PERPLEXITY_RESEARCH_MODEL)
     headers = {
         "Authorization": f"Bearer {PERPLEXITY_API_KEY()}",
@@ -42,6 +43,17 @@ def call(prompt: str, *, model: str | None = None, deep: bool = False, max_token
                     text = text.split("<think>")[0]
                 text = text.strip()
                 citations = data.get("citations") or data.get("search_results") or []
+                # Record the paid call in the shared usage ledger (fail-soft;
+                # log_call itself never raises). Token counts come from the
+                # OpenAI-shaped `usage` block when present.
+                u = data.get("usage") or {}
+                in_tok = int(u.get("prompt_tokens") or 0)
+                out_tok = int(u.get("completion_tokens") or 0)
+                usage.log_call(
+                    command, model, in_tok, out_tok,
+                    usage.estimate_perplexity_cost(model, in_tok, out_tok),
+                    extra={"provider": "perplexity"},
+                )
                 return {
                     "text": text,
                     "citations": citations,

--- a/scripts/research/lib/sources/brave.py
+++ b/scripts/research/lib/sources/brave.py
@@ -1,0 +1,62 @@
+"""Brave Search source. Optional keyed extra for the free-mode pool.
+
+Joins the aggregation pool only when BRAVE_API_KEY is set (the caller checks;
+see research._free_sources). Brave's free tier (2,000 queries/month as of
+2026-07, brave.com/search/api) makes this the cheapest keyed web source.
+Plain requests - no SDK. Design mirrors the fork that first built it
+(fork-insights round 2, the brave-source fork).
+"""
+
+from __future__ import annotations
+
+import os
+
+from .. import cache, http
+from ..result import Result
+from ..source_config import load
+
+API_URL = "https://api.search.brave.com/res/v1/web/search"
+
+
+class BraveSource:
+    name = "brave"
+
+    def __init__(self, retries: int = 1) -> None:
+        key = os.environ.get("BRAVE_API_KEY", "").strip()
+        if not key:
+            raise RuntimeError("BraveSource requires BRAVE_API_KEY")
+        self._key = key
+        self._session = http.get_session(retries=retries, backoff=1.0)
+        self._ttl = load().cache_ttl_hours
+
+    def search(self, query: str, n: int = 10) -> list[Result]:
+        cached = cache.get(self.name, query, ttl_hours=self._ttl)
+        if cached is not None:
+            return [Result(**r) for r in cached]
+
+        resp = self._session.get(
+            API_URL,
+            params={"q": query, "count": min(n, 20)},
+            headers={"X-Subscription-Token": self._key, "Accept": "application/json"},
+            timeout=http.DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        results = [
+            Result(
+                source=self.name,
+                title=item.get("title") or "",
+                url=item.get("url") or "",
+                snippet=item.get("description") or None,
+                posted_at=item.get("page_age") or None,
+            )
+            for item in (data.get("web") or {}).get("results", [])
+            if item.get("url")
+        ]
+        if results:
+            cache.put(self.name, query, results)
+        return results
+
+
+__all__ = ["BraveSource"]

--- a/scripts/research/lib/usage.py
+++ b/scripts/research/lib/usage.py
@@ -1,8 +1,12 @@
-"""Soft cost tracking for Grok API calls. No blocking, just visibility."""
+"""Soft cost tracking for paid API calls (Grok, Perplexity, Gemini).
+No blocking, just visibility - and fail-soft: a broken ledger must never
+abort the research call it is observing (fork-insights round 2, the
+api-ledger fork's pattern)."""
 
 from datetime import datetime
 from pathlib import Path
 import json
+import sys
 
 from .config import USAGE_LOG
 
@@ -13,26 +17,47 @@ GROK_PRICING = {
     "grok-3": {"input": 2.00, "output": 10.00},
 }
 
+# Pricing per 1M tokens (as of 2026-07, docs.perplexity.ai/getting-started/pricing;
+# request fees not modeled - this is an estimate for visibility, not billing).
+PERPLEXITY_PRICING = {
+    "sonar": {"input": 1.00, "output": 1.00},
+    "sonar-pro": {"input": 3.00, "output": 15.00},
+    "sonar-deep-research": {"input": 2.00, "output": 8.00},
+}
+
 
 def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     rates = GROK_PRICING.get(model, GROK_PRICING["grok-4.20-reasoning"])
     return (input_tokens / 1_000_000) * rates["input"] + (output_tokens / 1_000_000) * rates["output"]
 
 
+def estimate_perplexity_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+    rates = PERPLEXITY_PRICING.get(model)
+    if not rates:
+        return 0.0  # unknown model: log tokens, don't invent a price
+    return (input_tokens / 1_000_000) * rates["input"] + (output_tokens / 1_000_000) * rates["output"]
+
+
 def log_call(command: str, model: str, input_tokens: int, output_tokens: int, cost_usd: float, extra: dict | None = None) -> None:
-    USAGE_LOG.parent.mkdir(parents=True, exist_ok=True)
-    entry = {
-        "ts": datetime.now().isoformat(timespec="seconds"),
-        "command": command,
-        "model": model,
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-        "cost_usd": round(cost_usd, 4),
-    }
-    if extra:
-        entry.update(extra)
-    with USAGE_LOG.open("a") as f:
-        f.write(json.dumps(entry) + "\n")
+    """Append one JSONL line to the usage ledger. Fail-soft by contract: any
+    OS or encoding failure warns on stderr and returns - the paid call this
+    observes already succeeded, and observability must never break it."""
+    try:
+        USAGE_LOG.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "ts": datetime.now().isoformat(timespec="seconds"),
+            "command": command,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": round(cost_usd, 4),
+        }
+        if extra:
+            entry.update(extra)
+        with USAGE_LOG.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception as e:  # noqa: BLE001 - ledger is observability, never fatal
+        print(f"[usage ledger] could not record call ({e}); continuing", file=sys.stderr)
 
 
 def month_total() -> tuple[float, int]:

--- a/scripts/research/research.py
+++ b/scripts/research/research.py
@@ -85,13 +85,17 @@ def _free_sources(academic: bool):
         SemanticScholarSource(),
     ]
 
-    # Optional paid extra: Tavily joins the pool when its key is set. The
-    # shared .env is already loaded by main() via source_config (the #125
-    # lesson: never read a key before load_dotenv has run).
+    # Optional keyed extras join the pool when their key is set. The shared
+    # .env is already loaded by main() via source_config (the #125 lesson:
+    # never read a key before load_dotenv has run).
     if os.environ.get("TAVILY_API_KEY", "").strip():
         from .lib.sources.tavily import TavilySource
 
         sources.append(TavilySource())
+    if os.environ.get("BRAVE_API_KEY", "").strip():
+        from .lib.sources.brave import BraveSource
+
+        sources.append(BraveSource())
 
     return sources
 

--- a/scripts/research/research_deep.py
+++ b/scripts/research/research_deep.py
@@ -234,7 +234,7 @@ def run_paid_deep(topic: str) -> int:
     print(f"[/research-deep] Phase 2: identifying gaps via Perplexity (sonar-pro, fast)...", file=sys.stderr)
     gap_prompt = GAP_PROMPT.format(topic=topic, today=today, baseline=baseline)
     try:
-        gap_result = perplexity.call(gap_prompt, deep=False, max_tokens=2000)
+        gap_result = perplexity.call(gap_prompt, deep=False, max_tokens=2000, command="research-deep")
     except Exception as e:
         print(f"Phase 2 (gap analysis) failed: {e}", file=sys.stderr)
         return 1
@@ -250,7 +250,7 @@ def run_paid_deep(topic: str) -> int:
         try:
             if src == "web":
                 print(f"  [web] {q}", file=sys.stderr)
-                r = perplexity.call(f"Research this question: {q}\n\nReturn 3-5 specific facts with recency markers (date) and source domain. Be concise.", deep=False, max_tokens=1200)
+                r = perplexity.call(f"Research this question: {q}\n\nReturn 3-5 specific facts with recency markers (date) and source domain. Be concise.", deep=False, max_tokens=1200, command="research-deep")
                 findings_chunks.append(f"### Web - {q}\n\n{r['text']}")
                 for c in r.get("citations", []):
                     if isinstance(c, dict):
@@ -284,7 +284,7 @@ def run_paid_deep(topic: str) -> int:
     try:
         # Use sonar-reasoning-pro for synthesis (follows instructions, supports markdown structure).
         # sonar-deep-research has a hardcoded "10k-word academic narrative" that overrides our prompt.
-        synth = perplexity.call(synth_prompt, model="sonar-reasoning-pro", max_tokens=3500)
+        synth = perplexity.call(synth_prompt, model="sonar-reasoning-pro", max_tokens=3500, command="research-deep")
     except Exception as e:
         print(f"Phase 4 (synthesis) failed: {e}", file=sys.stderr)
         return 1

--- a/scripts/research/youtube_extract.py
+++ b/scripts/research/youtube_extract.py
@@ -18,6 +18,7 @@ Default behavior: print to chat AND save AI-first note to Research/YouTube/.
 
 import argparse
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -185,12 +186,24 @@ def main(argv: list[str]) -> int:
         comments_section=comments_section,
     )
 
-    print(f"[/youtube] Summarizing via Grok...\n", file=sys.stderr)
-    try:
-        result = grok.call(prompt, command="youtube", max_output_tokens=3000)
-    except Exception as e:
-        print(f"\n❌ /youtube summarize failed: {e}", file=sys.stderr)
-        return 1
+    # Prefer Gemini for the summary when its key is set (generous free tier),
+    # fall back to Grok - transparently, since gemini.call mirrors grok.call's
+    # return shape. No Gemini key = exactly the old Grok-only behavior.
+    result = None
+    if os.environ.get("GEMINI_API_KEY", "").strip():
+        print(f"[/youtube] Summarizing via Gemini (free tier)...\n", file=sys.stderr)
+        try:
+            from .lib import gemini
+            result = gemini.call(prompt, command="youtube", max_output_tokens=3000)
+        except Exception as e:  # noqa: BLE001 - fall back to Grok on any Gemini failure
+            print(f"[/youtube] Gemini failed ({e}); falling back to Grok...", file=sys.stderr)
+    if result is None:
+        print(f"[/youtube] Summarizing via Grok...\n", file=sys.stderr)
+        try:
+            result = grok.call(prompt, command="youtube", max_output_tokens=3000)
+        except Exception as e:
+            print(f"\n❌ /youtube summarize failed: {e}", file=sys.stderr)
+            return 1
 
     print(f"# {title}")
     print(f"**Channel:** {channel} · **Published:** {published}")

--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -27,6 +27,7 @@ A missing or malformed file is ignored silently. See VaultExcludes.
 
 import argparse
 import difflib
+import fnmatch
 import json
 import re
 import sys
@@ -89,15 +90,27 @@ class VaultExcludes:
 
         {
           "exclude-dirs":  ["_card-pool", "_candidates"],  # dir names, matched as path components
-          "exclude-paths": ["Archive/Backup"]              # vault-relative path prefixes (POSIX)
+          "exclude-paths": ["Archive/Backup"],             # vault-relative path prefixes (POSIX)
+          "exclude-link-scan": ["Meetings/2024-*"]         # globs: notes whose OUTGOING links are not audited
         }
+
+    `exclude-link-scan` exists because some notes echo every link they mention
+    without owning them - activity logs and prior health reports quote broken
+    links verbatim, so auditing them re-reports each finding once per echo
+    (fork-insights round 2). Built-in defaults: `_CLAUDE.md`, `log.md`, and
+    `Vault Health*` report notes. Globs match the bare filename and the
+    vault-relative path.
     """
 
-    __slots__ = ("dirs", "paths")
+    __slots__ = ("dirs", "paths", "link_scan")
 
-    def __init__(self, dirs=None, paths=None):
+    #: Notes whose outgoing links are never audited (see class docstring).
+    DEFAULT_LINK_SCAN_EXCLUDES = ("_CLAUDE.md", "log.md", "Vault Health*")
+
+    def __init__(self, dirs=None, paths=None, link_scan=None):
         self.dirs = dirs or set()
         self.paths = paths or []
+        self.link_scan = list(self.DEFAULT_LINK_SCAN_EXCLUDES) + list(link_scan or [])
 
     def skip(self, parts, rel_posix) -> bool:
         """True if a vault path is excluded from the scan (hardcoded + user rules)."""
@@ -106,6 +119,16 @@ class VaultExcludes:
         if self.dirs and any(p in self.dirs for p in parts):
             return True
         return any(rel_posix == pre or rel_posix.startswith(pre + "/") for pre in self.paths)
+
+    def skip_link_scan(self, rel_posix: str) -> bool:
+        """True if this note's OUTGOING links are excluded from the audit.
+        The note itself still resolves as a link target and is scanned by
+        every other check - only its outgoing-link report is suppressed."""
+        name = rel_posix.rsplit("/", 1)[-1]
+        return any(
+            fnmatch.fnmatch(name, pat) or fnmatch.fnmatch(rel_posix, pat)
+            for pat in self.link_scan
+        )
 
     def skip_file_index(self, parts) -> bool:
         """True if a path is excluded from the file index used for link resolution.
@@ -138,13 +161,17 @@ def load_vault_config(vault: Path) -> VaultExcludes:
         return VaultExcludes()
     raw_dirs = data.get("exclude-dirs", [])
     raw_paths = data.get("exclude-paths", [])
+    raw_link = data.get("exclude-link-scan", [])
     dirs = set()
     if isinstance(raw_dirs, list):
         dirs = {d for d in raw_dirs if isinstance(d, str) and d}
     paths = []
     if isinstance(raw_paths, list):
         paths = [p.strip("/") for p in raw_paths if isinstance(p, str) and p.strip("/")]
-    return VaultExcludes(dirs, paths)
+    link_scan = []
+    if isinstance(raw_link, list):
+        link_scan = [g for g in raw_link if isinstance(g, str) and g]
+    return VaultExcludes(dirs, paths, link_scan)
 
 
 def index_vault_files(vault: Path, excludes=None) -> set:
@@ -483,14 +510,16 @@ def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
         for alias in note["aliases"]:
             all_aliases[alias.lower()] = rel
 
-    # Operating manuals contain example wikilinks like [[wikilinks]], [[Related Project]],
-    # [[Links]] as syntax demonstrations, not as real references. Skip them from the
-    # scan so they don't generate dozens of false positives per scan.
-    SKIP_FROM_LINK_SCAN = {"_CLAUDE.md"}
+    # Some notes echo links without owning them: operating manuals show example
+    # wikilinks as syntax demonstrations, and activity logs / prior health
+    # reports quote every audited link verbatim - scanning them re-reports each
+    # finding once per echo. Defaults (_CLAUDE.md, log.md, Vault Health*) live
+    # on VaultExcludes; users extend via .vault-config.json "exclude-link-scan".
+    excludes = excludes or _NO_EXCLUDES
 
     issues = []
     for rel, note in notes.items():
-        if Path(rel).name in SKIP_FROM_LINK_SCAN:
+        if excludes.skip_link_scan(Path(rel).as_posix()):
             continue
         # Re-extract links from code-stripped content so example wikilinks inside
         # code fences / inline code are not counted (issue #82).

--- a/tests/test_research_sources.py
+++ b/tests/test_research_sources.py
@@ -248,6 +248,8 @@ def test_free_sources_gate_brave_on_key(monkeypatch):
 def test_usage_ledger_is_fail_soft(monkeypatch, tmp_path, capsys):
     """A broken ledger path must warn and return - never raise into the paid
     call it observes (the api-ledger fork's fail-soft contract)."""
+    # lib.config (pulled in by usage) hard-requires a vault path at import time.
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
     from scripts.research.lib import usage
 
     # Point the ledger at a path whose parent is a FILE - mkdir will fail.
@@ -259,7 +261,8 @@ def test_usage_ledger_is_fail_soft(monkeypatch, tmp_path, capsys):
     assert "could not record call" in capsys.readouterr().err
 
 
-def test_perplexity_cost_estimate_known_and_unknown_models():
+def test_perplexity_cost_estimate_known_and_unknown_models(monkeypatch, tmp_path):
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
     from scripts.research.lib import usage
 
     known = usage.estimate_perplexity_cost("sonar-pro", 1_000_000, 1_000_000)
@@ -274,8 +277,9 @@ def test_gemini_call_maps_response_and_uses_header_auth(monkeypatch, tmp_path):
     from unittest.mock import MagicMock
 
     monkeypatch.setenv("GEMINI_API_KEY", "gem-test-key")
-    monkeypatch.setattr("scripts.research.lib.usage.USAGE_LOG", tmp_path / "usage.log")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
     from scripts.research.lib import gemini
+    monkeypatch.setattr("scripts.research.lib.usage.USAGE_LOG", tmp_path / "usage.log")
 
     fake_resp = MagicMock()
     fake_resp.status_code = 200

--- a/tests/test_research_sources.py
+++ b/tests/test_research_sources.py
@@ -187,3 +187,113 @@ def test_free_sources_include_tavily_only_with_key(monkeypatch):
     # Academic mode stays untouched either way.
     academic = {type(s).__name__ for s in research._free_sources(academic=True)}
     assert "TavilySource" not in academic
+
+
+def test_brave_source_search(monkeypatch, tmp_path):
+    """BraveSource hits the REST API with the X-Subscription-Token header and
+    maps web.results to Result objects; rows without a URL are dropped."""
+    from unittest.mock import MagicMock
+
+    from scripts.research.lib.sources.brave import BraveSource
+
+    monkeypatch.setenv("BRAVE_API_KEY", "brv-test-key")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "web": {
+            "results": [
+                {"title": "Brave Result", "url": "https://example.com", "description": "A snippet"},
+                {"title": "dropped", "url": "", "description": "no url"},
+            ]
+        }
+    }
+    fake_resp.raise_for_status.return_value = None
+
+    src = BraveSource()
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_resp
+    src._session = fake_session
+
+    results = src.search("test query", n=5)
+
+    assert len(results) == 1
+    assert results[0].source == "brave"
+    assert results[0].title == "Brave Result"
+    assert results[0].snippet == "A snippet"
+    _, kwargs = fake_session.get.call_args
+    assert kwargs["headers"]["X-Subscription-Token"] == "brv-test-key"
+    assert kwargs["params"]["count"] == 5
+
+    monkeypatch.delenv("BRAVE_API_KEY")
+    with pytest.raises(RuntimeError):
+        BraveSource()
+
+
+def test_free_sources_gate_brave_on_key(monkeypatch):
+    """Brave joins the free-mode pool only when BRAVE_API_KEY is set."""
+    from scripts.research import research
+
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    without = {type(s).__name__ for s in research._free_sources(academic=False)}
+    assert "BraveSource" not in without
+
+    monkeypatch.setenv("BRAVE_API_KEY", "brv-test-key")
+    with_key = {type(s).__name__ for s in research._free_sources(academic=False)}
+    assert "BraveSource" in with_key
+
+
+def test_usage_ledger_is_fail_soft(monkeypatch, tmp_path, capsys):
+    """A broken ledger path must warn and return - never raise into the paid
+    call it observes (the api-ledger fork's fail-soft contract)."""
+    from scripts.research.lib import usage
+
+    # Point the ledger at a path whose parent is a FILE - mkdir will fail.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    monkeypatch.setattr(usage, "USAGE_LOG", blocker / "usage.log")
+
+    usage.log_call("research", "sonar-pro", 100, 200, 0.01)  # must not raise
+    assert "could not record call" in capsys.readouterr().err
+
+
+def test_perplexity_cost_estimate_known_and_unknown_models():
+    from scripts.research.lib import usage
+
+    known = usage.estimate_perplexity_cost("sonar-pro", 1_000_000, 1_000_000)
+    assert known == pytest.approx(3.00 + 15.00)
+    # Unknown model: log tokens, never invent a price.
+    assert usage.estimate_perplexity_cost("sonar-reasoning-pro", 1_000_000, 1_000_000) == 0.0
+
+
+def test_gemini_call_maps_response_and_uses_header_auth(monkeypatch, tmp_path):
+    """gemini.call returns the grok.call shape, and the key travels in the
+    x-goog-api-key header - never in the URL query string."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test-key")
+    monkeypatch.setattr("scripts.research.lib.usage.USAGE_LOG", tmp_path / "usage.log")
+    from scripts.research.lib import gemini
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {
+        "candidates": [{"content": {"parts": [{"text": "summary "}, {"text": "text"}]}}],
+        "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+    }
+
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(url=url, headers=headers)
+        return fake_resp
+
+    monkeypatch.setattr(gemini.requests, "post", fake_post)
+    result = gemini.call("summarize this", command="youtube")
+
+    assert result["text"] == "summary text"
+    assert result["input_tokens"] == 10 and result["output_tokens"] == 20
+    assert captured["headers"]["x-goog-api-key"] == "gem-test-key"
+    assert "key=" not in captured["url"]

--- a/tests/test_user_excludes.py
+++ b/tests/test_user_excludes.py
@@ -96,3 +96,37 @@ def test_malformed_config_is_silently_ignored(tmp_path):
     payload = _health(vault)
     assert isinstance(payload, dict)
     assert "issues" in payload
+
+
+def test_link_scan_defaults_skip_echo_notes(tmp_path):
+    """Broken links quoted in log.md or a prior Vault Health report must not be
+    re-reported (they echo findings, they don't own them) - while the same link
+    in a regular note IS reported."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "real.md").write_text("# Real\n\nSee [[Missing Note]].\n", encoding="utf-8")
+    (vault / "log.md").write_text("## 2026-07-18\n- flagged [[Missing Note]] and [[Echo Only]]\n", encoding="utf-8")
+    (vault / "Vault Health 2026-07-11.md").write_text("- broken: [[Echo Only]]\n", encoding="utf-8")
+
+    wanted = [i for i in _health(vault).get("issues", []) if i["type"] == "wanted_note"]
+    messages = " | ".join(i["message"] for i in wanted)
+    # The real note's link is still reported.
+    assert "Missing Note" in messages
+    # Echo Only appears ONLY in excluded notes, so it must not be reported at all.
+    assert "Echo Only" not in messages
+
+
+def test_link_scan_user_globs_from_config(tmp_path):
+    """`exclude-link-scan` globs in .vault-config.json extend the defaults."""
+    vault = tmp_path / "vault"
+    (vault / "Meetings").mkdir(parents=True)
+    (vault / "Meetings" / "2024-01-01 standup.md").write_text("[[Never Written]]\n", encoding="utf-8")
+    (vault / "Meetings" / "2026-01-01 standup.md").write_text("[[Never Written]]\n", encoding="utf-8")
+
+    _write_config(vault, {"exclude-link-scan": ["Meetings/2024-*"]})
+
+    wanted = [i for i in _health(vault).get("issues", []) if i["type"] == "wanted_note"]
+    files = [f for i in wanted for f in i["files"]]
+    # The 2026 meeting still reports its broken link; the 2024 one is excluded.
+    assert any("2026-01-01" in f for f in files)
+    assert not any("2024-01-01" in f for f in files)

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-second-brain-research"
-version = "0.12.0"
+version = "0.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
Ships the four P0 items from the round-2 fork sweep (FORK_INSIGHTS.md, 2026-07-18: 408 forks scanned, 26 diverging deep-read). Each pattern is credited to the fork that built it in the insights doc.

## 1. Brave Search source

`BRAVE_API_KEY` set -> Brave joins the `/research` free-mode pool (free tier: 2,000 queries/month). Without it, the pool stays fully key-less. Plain requests via the shared session/cache, `X-Subscription-Token` header, same shape as the Tavily source. Three forks independently built keyed web sources - the clearest demand signal in the sweep.

## 2. Usage ledger: fail-soft + Perplexity coverage

The existing ledger only logged Grok calls, and would raise on an unwritable path - failing the paid call it was observing. Now:
- `log_call` is fail-soft by contract (stderr warning, never raises)
- Every Perplexity call logs tokens + estimated cost (sonar / sonar-pro / sonar-deep-research rates as of 2026-07; unknown models log tokens with cost 0.0 rather than inventing a price)
- Entries are labeled per command, so `/research` vs `/research-deep` spend is auditable

## 3. /youtube via Gemini, Grok fallback

`GEMINI_API_KEY` set -> summaries go to `gemini-2.5-flash` (generous free tier); any Gemini failure falls back to Grok automatically; no Gemini key = exactly the old behavior. New `lib/gemini.py` mirrors `grok.call`'s return shape (drop-in swap), retries with backoff, logs to the ledger. One hygiene improvement over the fork's version: the key travels in the `x-goog-api-key` header, never the URL query string.

## 4. Health-check link-scan excludes

Activity logs and prior health reports quote every broken link they mention, so the wanted-notes scan re-reported each finding once per echo. Notes matching `_CLAUDE.md`, `log.md`, `Vault Health*` are now excluded from the outgoing-link audit by default (they still resolve as targets and get every other check), and `.vault-config.json` gains `exclude-link-scan` globs.

**Verified on a real 1,761-note vault**: 36 echo findings removed, all other findings identical (2,113 -> 2,077).

## Tests

10 new (Brave mapping + gating, ledger fail-soft, Perplexity pricing, Gemini header-auth + response mapping, link-scan defaults + user globs). Full suite **184 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)