### PR TITLE
Retire "Live Search" naming, default to grok-4.5, flag estimated costs

### DIFF
--- a/commands/create-command.md
+++ b/commands/create-command.md
@@ -104,7 +104,7 @@ Ask via AskUserQuestion (multi-select):
 
 > "Does this command call any external APIs?"
 > - Perplexity Sonar (web research)
-> - xAI Grok (X posts, Live Search)
+> - xAI Grok (X posts, x_search tool)
 > - YouTube Data API
 > - Other (free text)
 > - None - purely operates on the vault and conversation

--- a/commands/research-deep.md
+++ b/commands/research-deep.md
@@ -19,7 +19,7 @@ Use the obsidian-second-brain skill. Execute `/research-deep [topic]`:
 3. **Paid mode** - the script runs a 4-phase pipeline and finishes the work itself:
    - **Phase 1** - vault scan: finds existing notes mentioning the topic (the baseline).
    - **Phase 2** - gap analysis: Perplexity sonar-pro identifies what's missing/stale and emits 3-5 targeted queries (each tagged `web` or `x`).
-   - **Phase 3** - gap-fill: runs each query via Perplexity (web) or Grok+Live Search (X discourse).
+   - **Phase 3** - gap-fill: runs each query via Perplexity (web) or Grok x_search (X discourse).
    - **Phase 3.5** (optional) - if `TAVILY_API_KEY` is set, the top cited sources are fetched as full-page text (Tavily Extract, capped at 3 pages) and injected into the synthesis so it reads what the pages actually say, not just snippets. Skipped silently without the key - never require it.
    - **Phase 4** - synthesis: Perplexity produces a delta report, the script saves it to `Research/Deep/YYYY-MM-DD - <slug>.md`, then emits a JSON payload between `<<<RESEARCH_DEEP_PROPAGATION_PAYLOAD>>>` markers.
 

--- a/commands/x-pulse.md
+++ b/commands/x-pulse.md
@@ -1,5 +1,5 @@
 ---
-description: Scan X for what's trending in a topic - themes, voices, hooks, and post ideas powered by Grok + Live Search
+description: Scan X for what's trending in a topic - themes, voices, hooks, and post ideas powered by Grok x_search
 category: research
 triggers_en: ["x pulse", "what is trending on twitter", "scan x for", "twitter pulse"]
 triggers_es: ["x pulse", "qué es tendencia en twitter", "escanea x en busca de", "pulso de twitter"]

--- a/commands/x-read.md
+++ b/commands/x-read.md
@@ -1,5 +1,5 @@
 ---
-description: Deep-read an X (Twitter) post via Grok + Live Search - verbatim post, thread, TL;DR, claims, reply sentiment, voices to watch
+description: Deep-read an X (Twitter) post via Grok x_search - verbatim post, thread, TL;DR, claims, reply sentiment, voices to watch
 category: research
 triggers_en: ["read this x post", "deep read this tweet", "analyze this tweet", "read this thread"]
 triggers_es: ["léeme este post de x", "profundiza en este tweet", "analiza este tweet", "léeme este hilo"]

--- a/scripts/research/lib/config.py
+++ b/scripts/research/lib/config.py
@@ -30,7 +30,9 @@ PERPLEXITY_API_KEY = lambda: get_required("PERPLEXITY_API_KEY")
 GEMINI_API_KEY = lambda: get_required("GEMINI_API_KEY")
 YOUTUBE_API_KEY = lambda: get_optional("YOUTUBE_API_KEY", "")
 
-GROK_MODEL = get_optional("GROK_MODEL", "grok-4")
+# grok-4 no longer appears in GET /v1/models (it still resolves server-side, but is
+# unlisted). grok-4.5 is current and verified against the x_search tool.
+GROK_MODEL = get_optional("GROK_MODEL", "grok-4.5")
 PERPLEXITY_RESEARCH_MODEL = get_optional("PERPLEXITY_RESEARCH_MODEL", "sonar-pro")
 PERPLEXITY_DEEP_MODEL = get_optional("PERPLEXITY_DEEP_MODEL", "sonar-deep-research")
 NOTEBOOKLM_MODEL = get_optional("NOTEBOOKLM_MODEL", "gemini-2.5-flash")

--- a/scripts/research/lib/grok.py
+++ b/scripts/research/lib/grok.py
@@ -1,4 +1,9 @@
-"""xAI Grok client with Live Search support. Uses the /v1/responses endpoint."""
+"""xAI Grok client. Uses the Agent Tools API at /v1/responses.
+
+Live Search (`search_parameters` on /v1/chat/completions) was deprecated by xAI and
+now returns HTTP 410 — do not reintroduce it. Live X/web access comes from the
+`tools` argument below instead.
+"""
 
 import re
 import time
@@ -64,9 +69,11 @@ def call(
                                extra={"tools": [t.get("type") for t in (tools or [])]})
                 return {
                     "text": text,
+                    "model": model,
                     "input_tokens": input_tokens,
                     "output_tokens": output_tokens,
                     "cost_usd": cost,
+                    "cost_is_estimate": usage.is_estimate(model),
                     "raw": data,
                 }
             if r.status_code in (429, 500, 502, 503, 504):

--- a/scripts/research/lib/usage.py
+++ b/scripts/research/lib/usage.py
@@ -11,6 +11,13 @@ import sys
 from .config import USAGE_LOG
 
 # Pricing per 1M tokens (as of 2026-04, https://docs.x.ai/docs/models)
+#
+# STALE — do not trust for models not listed here. GET https://api.x.ai/v1/models now
+# returns authoritative per-token pricing (prompt_text_token_price /
+# completion_text_token_price), and it disagrees with this table: grok-4.3 reports a
+# 2:1 completion:prompt ratio, not the 5:1 assumed below. Unknown models fall back to
+# the grok-4.20-reasoning rate and are flagged via `is_estimate` so the number is not
+# reported as if it were exact.
 GROK_PRICING = {
     "grok-4.20-reasoning": {"input": 3.00, "output": 15.00},
     "grok-4": {"input": 3.00, "output": 15.00},
@@ -24,6 +31,11 @@ PERPLEXITY_PRICING = {
     "sonar-pro": {"input": 3.00, "output": 15.00},
     "sonar-deep-research": {"input": 2.00, "output": 8.00},
 }
+
+
+def is_estimate(model: str) -> bool:
+    """True when we have no real rate for this model and are guessing."""
+    return model not in GROK_PRICING
 
 
 def estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:

--- a/scripts/research/x_pulse.py
+++ b/scripts/research/x_pulse.py
@@ -13,7 +13,7 @@ from .lib import grok, vault
 
 PROMPT_TEMPLATE = """You are a social-media-aware analyst with live access to X. Topic: "{topic}"
 
-Use Live Search on X to scan posts from the last 24-72 hours about this topic. Return EXACTLY this structure (markdown), nothing else:
+Use the x_search tool to scan X posts from the last 24-72 hours about this topic. Return EXACTLY this structure (markdown), nothing else:
 
 WHAT'S HOT (last 24-72h)
 [3-5 emerging themes. For each theme:]
@@ -41,7 +41,7 @@ POST IDEAS FOR YOU TODAY
 Rules:
 - Do NOT add commentary outside this structure.
 - All URLs must be real x.com or twitter.com links you actually fetched (no fabrications).
-- If Live Search returns no current data on this topic, write "No active discourse found in last 72h on this topic." and stop.
+- If x_search returns no current data on this topic, write "No active discourse found in last 72h on this topic." and stop.
 """
 
 
@@ -52,11 +52,12 @@ def main(argv: list[str]) -> int:
 
     topic = " ".join(argv[1:]).strip()
     prompt = PROMPT_TEMPLATE.format(topic=topic)
-    print(f"[/x-pulse] Scanning X for '{topic}' via Grok + Live Search...\n", file=sys.stderr)
+    print(f"[/x-pulse] Scanning X for '{topic}' via Grok x_search...\n", file=sys.stderr)
 
     try:
         # /x-pulse synthesizes across many posts → uses the reasoning model.
-        # /x-read just extracts one post → grok-4 (default) is enough.
+        # (grok-4.20-reasoning is an alias; it resolves to grok-4.20-0309-reasoning.)
+        # /x-read just extracts one post → the grok-4.5 default handles it.
         result = grok.call(
             prompt,
             command="x-pulse",
@@ -76,7 +77,7 @@ def main(argv: list[str]) -> int:
     # AI-first note save
     now = datetime.now()
     preamble = (
-        f"For future Claude: This note is a Grok Live Search scan of X discourse "
+        f"For future Claude: This note is a Grok x_search scan of X discourse "
         f"about \"{topic}\" performed on {now.strftime('%Y-%m-%d %H:%M')}. It captures "
         f"emerging themes, gaps, hook formats, and content angles for the user's posting strategy. "
         f"X posts are time-sensitive - claims here may be stale within days."

--- a/scripts/research/x_read.py
+++ b/scripts/research/x_read.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""/x-read [url] - deep-read an X post via Grok + Live Search.
+"""/x-read [url] - deep-read an X post via Grok's x_search tool.
 
 Output: original post (verbatim) + TL;DR + key claims + reply sentiment + voices.
 Default behavior: print to chat. Does NOT save to vault unless the user explicitly asks.
@@ -55,7 +55,7 @@ def main(argv: list[str]) -> int:
         print("Continuing anyway - Grok will tell us if it can't fetch.", file=sys.stderr)
 
     prompt = PROMPT_TEMPLATE.format(url=url)
-    print(f"[/x-read] Fetching {url} via Grok + Live Search...\n", file=sys.stderr)
+    print(f"[/x-read] Fetching {url} via Grok x_search...\n", file=sys.stderr)
 
     try:
         result = grok.call(
@@ -71,8 +71,10 @@ def main(argv: list[str]) -> int:
         return 1
 
     print(result["text"])
+    approx = "~" if result.get("cost_is_estimate") else ""
     print(
-        f"\n---\n[cost: ${result['cost_usd']:.4f} · tokens in/out: {result['input_tokens']}/{result['output_tokens']}]",
+        f"\n---\n[cost: {approx}${result['cost_usd']:.4f} · {result.get('model', '?')}"
+        f" · tokens in/out: {result['input_tokens']}/{result['output_tokens']}]",
         file=sys.stderr,
     )
     return 0


### PR DESCRIPTION
xAI deprecated Live Search. `POST /v1/chat/completions` with a `search_parameters` block now returns:

```
HTTP 410 {"error":"Live search is deprecated. Please switch to the Agent Tools API: https://docs.x.ai/docs/guides/tools/overview"}
```

`lib/grok.py` already migrated to `/v1/responses` in eb39351, so **nothing here is broken** — this is the follow-up cleanup, plus two correctness fixes found while verifying it.

### 1. The name outlived the API

"Live Search" survived in docstrings, command descriptions, and — the part that actually matters — inside prompt text:

```python
"Use Live Search on X to scan posts from the last 24-72 hours…"
"If Live Search returns no current data on this topic, write…"
```

Those instruct the model to use a tool that no longer exists under that name. Renamed to `x_search` throughout, and left a note in `grok.py` so `search_parameters` isn't reintroduced.

### 2. Default `grok-4` → `grok-4.5`

`grok-4` is no longer listed by `GET /v1/models`. It still resolves (aliasing to `grok-4.3`), so this isn't breakage — but it's not just hygiene either. On the same `/x-read` prompt:

| model | REPLY SENTIMENT |
|---|---|
| `grok-4` (→ `grok-4.3`) | `Unable to fetch replies - sentiment not assessed.` |
| `grok-4.5` | `~67% highlighting GLM strength, 33% cautious/skeptical` + counter-arguments with handles |

Reply sentiment is a headline feature of `/x-read`, so the older model silently returns a degraded result. **Tradeoff worth your call:** roughly 2x cost per call (~\$0.02 → ~\$0.04). Happy to drop this hunk if you'd rather keep the cheaper default.

### 3. Cost estimates presented as exact

`GROK_PRICING` has no entry for `grok-4.5` or `grok-4.3`, so both fall back to the `grok-4.20-reasoning` rate and print a confident-looking number. `GET /v1/models` now returns authoritative per-token pricing, and it disagrees with the table — `grok-4.3` reports a 2:1 completion:prompt ratio, not the 5:1 assumed.

I did **not** invent replacement rates. Unknown models are flagged via `usage.is_estimate()`, and `/x-read` now prints:

```
[cost: ~$0.0373 · grok-4.5 · tokens in/out: 5219/1446]
```

The `~` marks it as an estimate. Wiring the table to the live pricing endpoint is the real fix — left as follow-up so this PR stays reviewable.

### Verification

Not just a compile check — four real X posts read end to end across `grok-4` and `grok-4.5`, confirming verbatim text, correct timestamps, and reply/counter-argument extraction. The 410 above was reproduced directly against the old endpoint. Rebased onto current `main` (v0.14.0) and re-verified after rebasing.

One hunk from my original branch was **dropped** during rebase: you'd already replaced the hardcoded name in the `/x-pulse` preamble with "the user's posting strategy" in #156. Your wording, kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)