### PR TITLE
vault_health: match links and stems on canonical Unicode form

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -31,6 +31,7 @@ import fnmatch
 import json
 import re
 import sys
+import unicodedata
 from collections import defaultdict
 from datetime import date
 from pathlib import Path
@@ -192,8 +193,8 @@ def index_vault_files(vault: Path, excludes=None) -> set:
             continue
         if not f.is_file():
             continue
-        files.add(f.relative_to(vault).as_posix().lower())
-        files.add(f.name.lower())
+        files.add(_nfc(f.relative_to(vault).as_posix()).lower())
+        files.add(_nfc(f.name).lower())
     return files
 
 
@@ -313,7 +314,7 @@ def check_orphans(notes: dict) -> list:
     link_sources: dict[str, set] = defaultdict(set)
     for src_rel, note in notes.items():
         for link in note["links"]:
-            lk = link.lower()
+            lk = _nfc(link).lower()
             # An incoming link may carry the .md extension ([[note.md]]); it still
             # targets the same note, so strip it before matching against stems.
             if lk.endswith(".md"):
@@ -334,9 +335,11 @@ def check_orphans(notes: dict) -> list:
             continue
         if rel in ("Home.md", "_CLAUDE.md"):
             continue
-        stem_lower = note["stem"].lower()
+        stem_lower = _nfc(note["stem"]).lower()
         stem_norm = stem_lower.replace("-", " ").replace("_", " ")
-        linked = _has_incoming(rel, {stem_lower, stem_norm, *note["aliases"]})
+        linked = _has_incoming(
+            rel, {stem_lower, stem_norm, *(_nfc(a) for a in note["aliases"])}
+        )
         if not linked:
             issues.append({
                 "type": "orphan",
@@ -478,6 +481,19 @@ def replace_outside_code(text: str, old: str, new: str) -> tuple[str, int]:
     return "".join(out), total
 
 
+def _nfc(s: str) -> str:
+    """Canonical (NFC) form of a string, for link/stem/alias comparison only.
+
+    Filenames and note content can disagree on Unicode composition: a decomposed
+    filename ("Gru" + U+0308 + "ndung.md") and a composed wikilink ("[[Grundung]]"
+    with U+00FC) are the same title to a human and to the filesystem, but not to a
+    plain string compare. Normalizing both sides at the comparison boundary keeps
+    accented titles from being reported as wanted notes or orphans. NFC (not NFKC):
+    only canonical equivalence, never compatibility folding.
+    """
+    return unicodedata.normalize("NFC", s)
+
+
 def _normalize_dashes(s: str) -> str:
     """Convert em-dash (U+2014) and en-dash (U+2013) to a regular hyphen.
 
@@ -495,20 +511,21 @@ def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
     (or instead of) writing its note. They are a demand-ranked wishlist of notes
     worth writing, so they are reported as info, not warnings. Named after
     MediaWiki's "Wanted pages"."""
-    all_stems = {note["stem"].lower(): rel for rel, note in notes.items()}
+    all_stems = {_nfc(note["stem"]).lower(): rel for rel, note in notes.items()}
     # Full-file index so links to non-markdown assets and links written with an
     # explicit extension resolve instead of being flagged broken.
     all_files = index_vault_files(vault, excludes)
     # also index stems with em-dashes normalized to regular hyphens so a
     # wikilink written with `-` still matches a filename written with `-`
     all_stems_dash_norm = {
-        _normalize_dashes(note["stem"]).lower(): rel for rel, note in notes.items()
+        _normalize_dashes(_nfc(note["stem"])).lower(): rel
+        for rel, note in notes.items()
     }
     # build alias → rel lookup so [[Full Name]] resolves if the note has that alias
     all_aliases: dict[str, str] = {}
     for rel, note in notes.items():
         for alias in note["aliases"]:
-            all_aliases[alias.lower()] = rel
+            all_aliases[_nfc(alias).lower()] = rel
 
     # Some notes echo links without owning them: operating manuals show example
     # wikilinks as syntax demonstrations, and activity logs / prior health
@@ -536,7 +553,7 @@ def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
             link_name = link.rsplit("/", 1)[-1]
             if link_name.lower().endswith(".md"):
                 link_name = link_name[:-3]
-            link_stem = link_name.lower()
+            link_stem = _nfc(link_name).lower()
             link_norm = link_stem.replace("-", " ").replace("_", " ")
             link_dash_norm = _normalize_dashes(link_stem)
             resolved = (
@@ -545,8 +562,8 @@ def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
                 or link_stem in all_aliases
                 or link_norm in all_aliases
                 or link_dash_norm in all_stems_dash_norm
-                or link.lower() in all_files
-                or f"{link.lower()}.md" in all_files
+                or _nfc(link).lower() in all_files
+                or f"{_nfc(link).lower()}.md" in all_files
             )
             if not resolved:
                 potential_folder = vault / link

--- a/tests/test_vault_health_unicode.py
+++ b/tests/test_vault_health_unicode.py
@@ -1,0 +1,104 @@
+"""vault_health Unicode: a link and a filename that differ only in Unicode
+composition are the same title and must resolve.
+
+Filesystems and tools disagree on composition. macOS HFS+ stores filenames
+decomposed (NFD); a title typed in an editor or pasted from a browser is usually
+composed (NFC). Any tool that copies a filename into a wikilink - or the reverse -
+can therefore produce a pair that a plain string compare rejects, even though both
+name the same note. Before NFC normalization at the comparison boundary, such a
+note was reported both as a wanted note (the link "goes nowhere") and as an orphan
+(nothing "links to" it) - two findings a user cannot act on, because the note is
+plainly there.
+
+The byte forms are written explicitly rather than relying on the host filesystem,
+so the test means the same thing on Linux CI as on macOS.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# "Gründung" - composed (single U+00FC) vs decomposed (u + U+0308).
+NFC_TITLE = "Gründung"
+NFD_TITLE = "Gründung"
+
+
+def _health(vault: Path) -> dict:
+    result = subprocess.run(
+        [sys.executable, "scripts/vault_health.py", "--path", str(vault), "--json"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout[result.stdout.find("{"):])
+
+
+def _types_for(report: dict, needle: str) -> set:
+    """Issue types whose message or files mention `needle`."""
+    hits = set()
+    for issue in report["issues"]:
+        blob = issue.get("message", "") + " ".join(issue.get("files", []))
+        if needle in blob:
+            hits.add(issue["type"])
+    return hits
+
+
+def _build(vault: Path, filename_title: str, link_title: str) -> None:
+    (vault / f"{filename_title}.md").write_text(
+        f"---\ndate: 2026-01-01\ntags:\n  - note\n---\n\n# {filename_title}\n",
+        encoding="utf-8",
+    )
+    (vault / "Hub.md").write_text(
+        f"---\ndate: 2026-01-01\ntags:\n  - note\n---\n\n"
+        f"# Hub\n\nSee [[{link_title}]] for background.\n",
+        encoding="utf-8",
+    )
+
+
+def test_nfd_filename_resolves_nfc_link(tmp_path: Path) -> None:
+    """Decomposed filename, composed link - the common macOS case."""
+    _build(tmp_path, NFD_TITLE, NFC_TITLE)
+    report = _health(tmp_path)
+
+    assert "wanted_note" not in _types_for(report, "ndung"), (
+        "a composed link to a decomposed filename must resolve"
+    )
+    assert "orphan" not in _types_for(report, "ndung"), (
+        "the linked note must not also be reported as an orphan"
+    )
+
+
+def test_nfc_filename_resolves_nfd_link(tmp_path: Path) -> None:
+    """The reverse: composed filename, decomposed link."""
+    _build(tmp_path, NFC_TITLE, NFD_TITLE)
+    report = _health(tmp_path)
+
+    assert "wanted_note" not in _types_for(report, "ndung"), (
+        "a decomposed link to a composed filename must resolve"
+    )
+    assert "orphan" not in _types_for(report, "ndung"), (
+        "the linked note must not also be reported as an orphan"
+    )
+
+
+def test_genuinely_missing_note_is_still_wanted(tmp_path: Path) -> None:
+    """Normalization must not silence real findings."""
+    (tmp_path / "Hub.md").write_text(
+        "---\ndate: 2026-01-01\ntags:\n  - note\n---\n\n"
+        "# Hub\n\nSee [[Nirgendwo]] for background.\n",
+        encoding="utf-8",
+    )
+    report = _health(tmp_path)
+
+    assert "wanted_note" in _types_for(report, "Nirgendwo"), (
+        "a link with no matching file must still be reported"
+    )


### PR DESCRIPTION
## The problem

A link and a filename that differ only in Unicode composition name the same note, but a plain
string compare rejects them. macOS HFS+ / APFS store filenames decomposed (NFD) while text typed
in an editor or pasted from a browser is usually composed (NFC), so any tool that copies a
filename into a wikilink, or the reverse, can produce such a pair.

The note then shows up twice in a report the user cannot act on: once as a wanted note (the link
"goes nowhere") and once as an orphan (nothing "links to" it), while the note is plainly sitting
there. On a real 1074-note vault with German titles this accounted for a large share of both
categories.

Any vault with non-ASCII titles is affected: German umlauts, Spanish and Portuguese accents,
French diacritics. Pure ASCII vaults are unaffected.

## The change

Normalize to NFC at the comparison boundary only: stem, alias, asset and link-source keys, plus
the link side in `check_wanted_notes`. Not on note content at read time, which would also change
the reported note size.

NFC, not NFKC: canonical equivalence only, never compatibility folding, so distinct titles stay
distinct. `unicodedata` is already a dependency of the repo (`scripts/heal_links.py`).

The change can only make a previously unresolvable link resolve, never the reverse.

## Tests

Three cases in `tests/test_vault_health_unicode.py` cover both directions plus a genuinely
missing note. The byte forms are written explicitly rather than relying on the filesystem, so the
assertions mean the same thing on Linux CI as on macOS.

Full suite: 197 passed.

Happy to add a CHANGELOG entry under Unreleased if you want it in the same PR.
