### PR TITLE
fix(exceptions): preserve original exception context with `from e` (fixes #165)

### DIFF
--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -163,12 +163,13 @@ def transcribe_local(audio, suffix):
             cmd += ["--initial_prompt", WHISPER_HINT]
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             raise RuntimeError(
                 f"local transcription needs the '{WHISPER_BIN}' CLI - "
-                "pip install openai-whisper (and install ffmpeg), or set WHISPER_BIN")
+                "pip install openai-whisper (and install ffmpeg), or set WHISPER_BIN"
+            ) from e
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"whisper failed: {(e.stderr or '').strip()[-300:]}")
+            raise RuntimeError(f"whisper failed: {(e.stderr or '').strip()[-300:]}") from e
         out = pathlib.Path(tmp) / f"{src.stem}.txt"
         return out.read_text().strip() if out.exists() else ""
 

--- a/scripts/research/lib/podcast.py
+++ b/scripts/research/lib/podcast.py
@@ -150,10 +150,10 @@ def parse_feed(
     """Parse an RSS feed and return episode metadata + audio URL + show-notes + transcript-tag-url."""
     try:
         import feedparser
-    except ImportError:
+    except ImportError as e:
         raise RuntimeError(
             "feedparser is required. Install with: uv sync (or pip install feedparser)"
-        )
+        ) from e
     parsed = feedparser.parse(feed_url)
     if parsed.bozo and not parsed.entries:
         raise ValueError(f"Could not parse feed at {feed_url}: {parsed.bozo_exception}")

--- a/scripts/research/lib/video_frames.py
+++ b/scripts/research/lib/video_frames.py
@@ -69,8 +69,8 @@ def download_video(url: str, out_dir: Path) -> dict:
     try:
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                        check=False, timeout=600)
-    except subprocess.TimeoutExpired:
-        raise FrameError(f"yt-dlp timed out after 600s downloading {url}")
+    except subprocess.TimeoutExpired as e:
+        raise FrameError(f"yt-dlp timed out after 600s downloading {url}") from e
 
     video = _pick_video(out_dir)
     if video is None:


### PR DESCRIPTION
## Summary
Fixes #165.

## Changes
Preserves original exception context () when catching and re-raising exceptions in:
- `integrations/telegram-journal/telegram_journal.py`
- `scripts/research/lib/podcast.py`
- `scripts/research/lib/video_frames.py`

This ensures Python's traceback mechanism includes full cause chaining instead of hiding the underlying exception.

## Verification
- Ran full test suite via `uv run pytest`: 370 tests passed.