### PR TITLE
Enable ruff import-sorting (I) rules in lint gate

### DIFF
--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -22,9 +22,8 @@ import sys
 # launches us from.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from mcp.server.fastmcp import FastMCP  # noqa: E402
-
 import vault_ops  # noqa: E402
+from mcp.server.fastmcp import FastMCP  # noqa: E402
 
 mcp = FastMCP("obsidian-second-brain")
 

--- a/integrations/obsidian-mcp-server/vault_ops.py
+++ b/integrations/obsidian-mcp-server/vault_ops.py
@@ -11,13 +11,13 @@ with type/date/tags/ai-first, a `## For future Claude` preamble, and a
 from __future__ import annotations
 
 import json
-from collections import OrderedDict
 import math
 import os
 import re
 import sys
 import unicodedata
 import urllib.request
+from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional

--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -22,14 +22,14 @@ Config/secrets come from ~/.config/obsidian-second-brain/telegram_journal.env
 TRANSCRIBE_BACKEND=openai, the default), ANTHROPIC_API_KEY, VAULT_PATH
 This file holds no secrets and is safe to read or share.
 """
-import os
-import re
-import sys
-import json
 import base64
 import datetime
+import json
+import os
 import pathlib
+import re
 import subprocess
+import sys
 
 import requests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ target-version = "py310"
 #   E731  lambda assignment. Used intentionally in research/lib/config.py.
 # Widening this list means fixing the backlog first, not adding a noqa sweep.
 [tool.ruff.lint]
-select = ["F"]
+select = ["F","I"]

--- a/scripts/bootstrap_vault.py
+++ b/scripts/bootstrap_vault.py
@@ -32,9 +32,9 @@ Options:
 
 import argparse
 import sys
-from typing import NamedTuple
-from pathlib import Path
 from datetime import date
+from pathlib import Path
+from typing import NamedTuple
 
 # Force UTF-8 stdout/stderr so emoji print statements work on Windows (cp1252).
 for _stream in (sys.stdout, sys.stderr):

--- a/scripts/eval/semantic_search.py
+++ b/scripts/eval/semantic_search.py
@@ -33,8 +33,8 @@ import os
 import re
 import sys
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 from pathlib import Path
 
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434").rstrip("/")
@@ -56,8 +56,10 @@ EXCLUDE_PREFIXES = tuple(
 # index and the lexical scan can never drift into different universes
 # (stress-test fix 10/24).
 import sys as _sys
+
 _sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "integrations" / "obsidian-mcp-server"))
 from vault_ops import _SKIP_DIRS as SKIP_DIRS  # noqa: E402
+
 INDEX_FILE = ".obsidian-semantic-index.json"  # written at vault root
 # Embedding models have a token limit (typically ~512 tokens). Long notes
 # must be split into safe chunks and averaged, or the model 500s. ~1200 chars sits

--- a/scripts/export_okf.py
+++ b/scripts/export_okf.py
@@ -23,13 +23,13 @@ Usage:
   uv run scripts/export_okf.py --path "/path/to/Vault" [--out _export/okf]
 """
 import argparse
+import datetime
 import html
 import os
-import unicodedata
+import pathlib
 import re
 import sys
-import datetime
-import pathlib
+import unicodedata
 
 import yaml
 
@@ -45,9 +45,13 @@ WIKILINK_RE = re.compile(r"(!?)\[\[([^\]]+)\]\]")
 # vault_health.load_vault), so the canonical capital Templates/ stays out too.
 import sys as _sys
 from pathlib import Path as _Path
+
 _sys.path.insert(0, str(_Path(__file__).resolve().parent))
-from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
-from vault_scan import EXPORT_ONLY_EXCLUDES  # noqa: E402
+from vault_scan import (
+    BASE_EXCLUDE_DIRS,  # noqa: E402
+    EXPORT_ONLY_EXCLUDES,  # noqa: E402
+)
+
 # Base policy plus the one skip that is specific to exporting: drawings are
 # not exportable prose.
 SKIP_DIRS = frozenset(d.lower() for d in (*BASE_EXCLUDE_DIRS, *EXPORT_ONLY_EXCLUDES))

--- a/scripts/freshness_lint.py
+++ b/scripts/freshness_lint.py
@@ -29,15 +29,16 @@ from __future__ import annotations
 
 import sys as _sys
 from pathlib import Path as _Path
-_sys.path.insert(0, str(_Path(__file__).resolve().parent))
-from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
 
+_sys.path.insert(0, str(_Path(__file__).resolve().parent))
 import argparse
 import json
 import re
 import sys
 from datetime import date, datetime
 from pathlib import Path
+
+from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
 
 DEFAULT_WINDOW_DAYS = 7
 

--- a/scripts/heal_links.py
+++ b/scripts/heal_links.py
@@ -39,9 +39,7 @@ from pathlib import Path
 
 # reuse the EXACT detection the health check uses, so our count == its count
 from note_io import read_exact, write_exact
-
-from vault_health import (load_vault, check_wanted_notes, replace_outside_code,
-                          load_vault_config)
+from vault_health import check_wanted_notes, load_vault, load_vault_config, replace_outside_code
 
 DECORATION = re.compile(r"[#|].*$")          # a #heading anchor or |display alias
 LINK_IN_MSG = re.compile(r"\[\[(.+?)\]\] - wanted by ")

--- a/scripts/link_graph.py
+++ b/scripts/link_graph.py
@@ -25,9 +25,8 @@ from __future__ import annotations
 
 import sys as _sys
 from pathlib import Path as _Path
-_sys.path.insert(0, str(_Path(__file__).resolve().parent))
-from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
 
+_sys.path.insert(0, str(_Path(__file__).resolve().parent))
 import argparse
 import json
 import re
@@ -37,6 +36,7 @@ from pathlib import Path
 
 # Shared with the health check so the two tools cannot drift apart again.
 from vault_health import index_vault_files
+from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
 
 SKIP_DIRS = frozenset(d.lower() for d in BASE_EXCLUDE_DIRS)  # see scripts/vault_scan.py
 

--- a/scripts/research/lib/aggregator.py
+++ b/scripts/research/lib/aggregator.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import sys
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeout
 from dataclasses import asdict
 from typing import Any, Protocol
 

--- a/scripts/research/lib/config.py
+++ b/scripts/research/lib/config.py
@@ -1,8 +1,9 @@
 """Loads research-toolkit credentials and model defaults from ~/.config/obsidian-second-brain/.env"""
 
-from pathlib import Path
-from dotenv import load_dotenv
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 CONFIG_DIR = Path.home() / ".config" / "obsidian-second-brain"
 ENV_PATH = CONFIG_DIR / ".env"

--- a/scripts/research/lib/grok.py
+++ b/scripts/research/lib/grok.py
@@ -7,11 +7,12 @@ now returns HTTP 410 - do not reintroduce it. Live X/web access comes from the
 
 import re
 import time
-import requests
 from typing import Any
 
-from .config import GROK_MODEL, XAI_API_KEY
+import requests
+
 from . import usage
+from .config import GROK_MODEL, XAI_API_KEY
 
 # Strip Grok's internal tool-call protocol XML if it leaks into output text.
 # Seen patterns:

--- a/scripts/research/lib/perplexity.py
+++ b/scripts/research/lib/perplexity.py
@@ -2,11 +2,12 @@
 
 import re
 import time
-import requests
 from typing import Any
 
+import requests
+
 from . import usage
-from .config import PERPLEXITY_API_KEY, PERPLEXITY_RESEARCH_MODEL, PERPLEXITY_DEEP_MODEL
+from .config import PERPLEXITY_API_KEY, PERPLEXITY_DEEP_MODEL, PERPLEXITY_RESEARCH_MODEL
 
 API_URL = "https://api.perplexity.ai/chat/completions"
 MAX_RETRIES = 3

--- a/scripts/research/lib/podcast.py
+++ b/scripts/research/lib/podcast.py
@@ -19,7 +19,7 @@ import re
 import sys
 import tempfile
 from typing import Any
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 import requests
 

--- a/scripts/research/lib/sources/arxiv.py
+++ b/scripts/research/lib/sources/arxiv.py
@@ -6,8 +6,8 @@ import re
 import xml.etree.ElementTree as ET
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "http://export.arxiv.org/api/query"
 NS = {

--- a/scripts/research/lib/sources/crossref.py
+++ b/scripts/research/lib/sources/crossref.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://api.crossref.org/works"
 

--- a/scripts/research/lib/sources/devto.py
+++ b/scripts/research/lib/sources/devto.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://dev.to/api/articles"
 

--- a/scripts/research/lib/sources/duckduckgo.py
+++ b/scripts/research/lib/sources/duckduckgo.py
@@ -11,8 +11,8 @@ from html import unescape
 from urllib.parse import parse_qs, unquote, urlparse
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 DDG = "https://html.duckduckgo.com/html/"
 RESULT_RE = re.compile(

--- a/scripts/research/lib/sources/hackernews.py
+++ b/scripts/research/lib/sources/hackernews.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://hn.algolia.com/api/v1/search"
 

--- a/scripts/research/lib/sources/lobsters.py
+++ b/scripts/research/lib/sources/lobsters.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://lobste.rs/search.json"
 

--- a/scripts/research/lib/sources/openalex.py
+++ b/scripts/research/lib/sources/openalex.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://api.openalex.org/works"
 

--- a/scripts/research/lib/sources/reddit.py
+++ b/scripts/research/lib/sources/reddit.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import time
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://www.reddit.com/search.json"
 

--- a/scripts/research/lib/sources/semantic_scholar.py
+++ b/scripts/research/lib/sources/semantic_scholar.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 ENDPOINT = "https://api.semanticscholar.org/graph/v1/paper/search"
 FIELDS = "title,abstract,authors,year,url,externalIds"

--- a/scripts/research/lib/sources/wikipedia.py
+++ b/scripts/research/lib/sources/wikipedia.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import urllib.parse
 
 from .. import cache, http
-from ..source_config import load
 from ..result import Result
+from ..source_config import load
 
 SEARCH = "https://en.wikipedia.org/w/api.php"
 SUMMARY = "https://en.wikipedia.org/api/rest_v1/page/summary/"

--- a/scripts/research/lib/usage.py
+++ b/scripts/research/lib/usage.py
@@ -3,9 +3,9 @@ No blocking, just visibility - and fail-soft: a broken ledger must never
 abort the research call it is observing (fork-insights round 2, the
 api-ledger fork's pattern)."""
 
-from datetime import datetime
 import json
 import sys
+from datetime import datetime
 
 from .config import USAGE_LOG
 

--- a/scripts/research/lib/vault.py
+++ b/scripts/research/lib/vault.py
@@ -10,9 +10,9 @@ Each note follows the AI-first vault rule:
 7. Confidence levels (where applicable)
 """
 
+import re
 from datetime import datetime
 from pathlib import Path
-import re
 from typing import Any
 from urllib.parse import quote
 

--- a/scripts/research/lib/youtube.py
+++ b/scripts/research/lib/youtube.py
@@ -45,12 +45,12 @@ def get_video_metadata(video_id: str) -> dict[str, Any] | None:
     if not key:
         return None
     try:
-        from googleapiclient.discovery import build
         # An explicit transport timeout. Without one googleapiclient falls back to
         # httplib2's default of none, so a slow (not down) Data API blocks the whole
         # /youtube command - including the plain non-visual path - with no bound and
         # no way for the caller to recover. Matches lib/http.py's DEFAULT_TIMEOUT.
         import httplib2
+        from googleapiclient.discovery import build
         yt = build("youtube", "v3", developerKey=key, cache_discovery=False,
                    http=httplib2.Http(timeout=15))
         resp = yt.videos().list(part="snippet,statistics,contentDetails", id=video_id).execute()
@@ -83,12 +83,12 @@ def get_top_comments(video_id: str, max_results: int = 20) -> list[dict[str, Any
     if not key:
         return []
     try:
-        from googleapiclient.discovery import build
         # An explicit transport timeout. Without one googleapiclient falls back to
         # httplib2's default of none, so a slow (not down) Data API blocks the whole
         # /youtube command - including the plain non-visual path - with no bound and
         # no way for the caller to recover. Matches lib/http.py's DEFAULT_TIMEOUT.
         import httplib2
+        from googleapiclient.discovery import build
         yt = build("youtube", "v3", developerKey=key, cache_discovery=False,
                    http=httplib2.Http(timeout=15))
         resp = yt.commentThreads().list(

--- a/scripts/research/podcast_extract.py
+++ b/scripts/research/podcast_extract.py
@@ -16,6 +16,7 @@ the episode is resolved to its open feed and pulled from there, never from Spoti
 import os
 import sys
 from datetime import datetime
+
 from .lib import grok, podcast, vault
 
 SUMMARIZE_PROMPT = """You are summarizing a podcast episode for a knowledge vault. The note will be read by future-Claude (an AI), not by a human. Optimize for AI retrieval.

--- a/scripts/research/research_deep.py
+++ b/scripts/research/research_deep.py
@@ -22,6 +22,7 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
+
 from .lib.config import VAULT_PATH
 
 VAULT_SCAN_DIRS = ["wiki", "Research", "Knowledge", "Projects", "Ideas"]
@@ -222,7 +223,7 @@ def run_free_deep(topic: str, academic: bool) -> int:
 
 
 def run_paid_deep(topic: str) -> int:
-    from .lib import perplexity, grok, vault
+    from .lib import grok, perplexity, vault
 
     today = datetime.now().strftime("%Y-%m-%d")
 

--- a/scripts/research/x_pulse.py
+++ b/scripts/research/x_pulse.py
@@ -7,6 +7,7 @@ Default behavior: print to chat AND save AI-first note to Research/X-pulse/.
 
 import sys
 from datetime import datetime
+
 from .lib import grok, vault
 
 PROMPT_TEMPLATE = """You are a social-media-aware analyst with live access to X. Topic: "{topic}"

--- a/scripts/research/x_read.py
+++ b/scripts/research/x_read.py
@@ -6,6 +6,7 @@ Default behavior: print to chat. Does NOT save to vault unless the user explicit
 """
 
 import sys
+
 from .lib import grok
 
 PROMPT_TEMPLATE = """Analyze this X post and return a structured deep-read.

--- a/scripts/research/youtube_extract.py
+++ b/scripts/research/youtube_extract.py
@@ -25,7 +25,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-from .lib import grok, video_frames, vault, youtube
+from .lib import grok, vault, video_frames, youtube
 
 # Frames the visual layer reads by default. Kept modest: each frame is an image
 # Claude reads, so cost scales with count. Override with --max-frames.

--- a/scripts/triage_links.py
+++ b/scripts/triage_links.py
@@ -19,8 +19,7 @@ from datetime import date
 from pathlib import Path
 
 from note_io import read_exact, write_exact
-from vault_health import (load_vault, check_wanted_notes, replace_outside_code,
-                          load_vault_config)
+from vault_health import check_wanted_notes, load_vault, load_vault_config, replace_outside_code
 
 LINK_IN_MSG = re.compile(r"\[\[(.+?)\]\]")
 MODEL = "claude-haiku-4-5"

--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -31,13 +31,13 @@ import fnmatch
 import json
 import re
 import sys
+import sys as _sys
 import unicodedata
 from collections import defaultdict
 from datetime import date
 from pathlib import Path
-
-import sys as _sys
 from pathlib import Path as _Path
+
 _sys.path.insert(0, str(_Path(__file__).resolve().parent))
 from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
 

--- a/scripts/vault_stats.py
+++ b/scripts/vault_stats.py
@@ -34,9 +34,13 @@ FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 # All values are lowercase - comparison uses part.lower() so casing in the vault doesn't matter.
 import sys as _sys
 from pathlib import Path as _Path
+
 _sys.path.insert(0, str(_Path(__file__).resolve().parent))
-from vault_scan import BASE_EXCLUDE_DIRS  # noqa: E402
-from vault_scan import STATS_ONLY_EXCLUDES  # noqa: E402
+from vault_scan import (
+    BASE_EXCLUDE_DIRS,  # noqa: E402
+    STATS_ONLY_EXCLUDES,  # noqa: E402
+)
+
 # Base policy plus raw/ and references/, which are real vault content but not
 # user notes for the purpose of counting.
 EXCLUDED_FOLDERS = frozenset(d.lower() for d in (*BASE_EXCLUDE_DIRS, *STATS_ONLY_EXCLUDES))

--- a/tests/test_bootstrap_unit.py
+++ b/tests/test_bootstrap_unit.py
@@ -26,7 +26,6 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import bootstrap_vault as bv  # noqa: E402
 
-
 # --- S19: write() ----------------------------------------------------------
 
 def test_write_creates_a_missing_file(tmp_path):

--- a/tests/test_eval_ruler.py
+++ b/tests/test_eval_ruler.py
@@ -19,8 +19,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "integrations" / "obsidian-mcp-server"))
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "eval"))
 
-import vault_ops  # noqa: E402
 import retrieval_eval as rev  # noqa: E402
+import vault_ops  # noqa: E402
 
 
 @pytest.fixture()

--- a/tests/test_exclude_policy.py
+++ b/tests/test_exclude_policy.py
@@ -39,12 +39,12 @@ def test_the_base_covers_every_machine_owned_directory():
 
 def test_every_scanning_tool_uses_the_base():
     """The regression this file exists for."""
-    from vault_scan import BASE_EXCLUDE_DIRS
     import export_okf
     import freshness_lint
     import link_graph
     import vault_health
     import vault_stats
+    from vault_scan import BASE_EXCLUDE_DIRS
 
     base = _lower(BASE_EXCLUDE_DIRS)
     for name, actual in (
@@ -60,8 +60,8 @@ def test_every_scanning_tool_uses_the_base():
 
 def test_the_mcp_server_literal_matches_the_base():
     """vault_ops cannot import from scripts/, so it is pinned instead."""
-    from vault_scan import BASE_EXCLUDE_DIRS
     import vault_ops
+    from vault_scan import BASE_EXCLUDE_DIRS
 
     missing = _lower(BASE_EXCLUDE_DIRS) - _lower(vault_ops._SKIP_DIRS)
     assert not missing, (

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "integrations" / "obsidian-mcp-server"))
 

--- a/tests/test_multilingual_model.py
+++ b/tests/test_multilingual_model.py
@@ -16,8 +16,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "integrations" / "obsidian-mcp-server"))
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "eval"))
 
-import vault_ops  # noqa: E402
 import semantic_search as ss  # noqa: E402
+import vault_ops  # noqa: E402
 
 
 def test_default_model_is_multilingual():

--- a/tests/test_p1_p2_fixes.py
+++ b/tests/test_p1_p2_fixes.py
@@ -103,6 +103,7 @@ def test_update_note_reports_a_retrieval_affecting_status(tmp_path, monkeypatch)
     (v / "n.md").write_text("---\ntype: note\n---\n\nbody\n", encoding="utf-8")
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(v))
     import importlib
+
     import vault_ops
     importlib.reload(vault_ops)
 

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 import json
 import re
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_ranking_quality.py
+++ b/tests/test_ranking_quality.py
@@ -20,8 +20,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "integrations" / "obsidian-mcp-server"))
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "eval"))
 
-import vault_ops  # noqa: E402
 import semantic_search as ss  # noqa: E402
+import vault_ops  # noqa: E402
 
 
 @pytest.fixture()

--- a/tests/test_research_sources.py
+++ b/tests/test_research_sources.py
@@ -16,10 +16,9 @@ import os
 
 import pytest
 
-from scripts.research.lib import cache, http
+from scripts.research.lib import cache, http, source_config
 from scripts.research.lib.aggregator import aggregate
 from scripts.research.lib.result import Result, encode_results
-from scripts.research.lib import source_config
 
 
 def test_library_imports_without_vault_path():

--- a/tests/test_setup_and_manual_drift.py
+++ b/tests/test_setup_and_manual_drift.py
@@ -23,7 +23,6 @@ import stat
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL = REPO_ROOT / "SKILL.md"
 COMMANDS = REPO_ROOT / "commands"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_untrusted_source_handling.py
+++ b/tests/test_untrusted_source_handling.py
@@ -113,6 +113,7 @@ def test_a_poisoned_note_is_filtered_out_of_automatic_recall(tmp_path, monkeypat
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
 
     import importlib
+
     import vault_ops
     importlib.reload(vault_ops)
 


### PR DESCRIPTION
What changed
- Added I (isort/import-sorting) to the select list in [tool.ruff.lint] in pyproject.toml, alongside the existing F (pyflakes) rules
- Ran ruff check . --select I --fix to auto-sort imports across the codebase — this touched every file with unsorted imports (mostly reordering only, no logic changes)
- Verified ruff check . passes clean with the widened gate
- Testing

- Ran the full test suite (pytest) on this branch: 39 failed, 456 passed, 1 skipped, 32 errors
- Ran the same suite on unmodified main for comparison: identical result (39 failed, 456 passed, 1 skipped, 32 errors)
- Confirms these failures are pre-existing (likely due to missing API keys / network access needed for the research integrations) and unrelated to this change