### PR TITLE
Fix #164: enforce equal-length vectors with zip(strict=True)

### DIFF
--- a/integrations/obsidian-mcp-server/vault_ops.py
+++ b/integrations/obsidian-mcp-server/vault_ops.py
@@ -173,7 +173,7 @@ def _freshness_rerank(results, vault: Path, current_intent: bool):
                 superseded_targets.add(PurePosixPath(target.strip()).stem.lower())
 
     rescored = []
-    for i, (r, head) in enumerate(zip(results, heads)):
+    for i, (r, head) in enumerate(zip(results, heads, strict=True)):
         weight = 1.0
         sm = _STATUS_RE.search(head)
         if sm and sm.group(1).lower() in _STALE_STATUSES:
@@ -313,7 +313,11 @@ def resolve_vault() -> Path:
 def _cosine(a: List[float], b: List[float]) -> float:
     if not a or not b or len(a) != len(b):
         return 0.0
-    dot = sum(x * y for x, y in zip(a, b))
+    # strict=True: a and b are already verified equal-length above, so this
+    # never raises. It documents that invariant instead of letting a future
+    # edit that removes the length check silently reintroduce a truncated,
+    # wrong-but-plausible-looking dot product (see #164).
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
     return dot / (na * nb) if na and nb else 0.0
@@ -339,7 +343,11 @@ def _dot(a: List[float], b: List[float]) -> float:
     """
     if len(a) != len(b):
         return 0.0
-    return sum(x * y for x, y in zip(a, b))
+    # strict=True: see _cosine above - this is defence in depth, not a live
+    # bug fix, since the length check just above already guarantees a and b
+    # match. It's called in a tight loop over every chunk in the vault, so
+    # keep it a documented invariant rather than a silent truncation risk.
+    return sum(x * y for x, y in zip(a, b, strict=True))
 
 
 def _embed_query(text: str, model: Optional[str] = None) -> Optional[List[float]]:

--- a/scripts/eval/semantic_search.py
+++ b/scripts/eval/semantic_search.py
@@ -238,7 +238,9 @@ def cosine(a: list[float], b: list[float]) -> float:
     """Cosine similarity in [-1, 1]; how close two meaning-coordinates point."""
     if not a or not b or len(a) != len(b):
         return 0.0
-    dot = sum(x * y for x, y in zip(a, b))
+    # strict=True: a and b are already verified equal-length above, so this
+    # never raises here - it documents the invariant for future edits (#164).
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
     na = math.sqrt(sum(x * x for x in a))
     nb = math.sqrt(sum(y * y for y in b))
     if na == 0 or nb == 0:

--- a/tests/test_vector_math.py
+++ b/tests/test_vector_math.py
@@ -1,0 +1,59 @@
+"""Vector math used to rank every semantic search result (issue #164).
+
+_cosine/_dot in vault_ops.py and cosine() in scripts/eval/semantic_search.py
+each guard `len(a) != len(b)` before summing with zip(), so a length
+mismatch already returns 0.0 rather than silently scoring a truncated
+partial dot product. zip(..., strict=True) turns that guard into an
+enforced invariant: if a future edit ever removes the length check, the
+zip raises instead of quietly resuming the old failure mode (a plausible-
+looking but wrong similarity score) - see the issue for how bad that
+failure mode is: nothing in the output distinguishes a genuinely weak
+match from a comparison that silently dropped half its dimensions.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "integrations" / "obsidian-mcp-server"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "eval"))
+
+import vault_ops  # noqa: E402
+import semantic_search as ss  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [vault_ops._cosine, vault_ops._dot, ss.cosine],
+    ids=["vault_ops._cosine", "vault_ops._dot", "semantic_search.cosine"],
+)
+def test_mismatched_length_returns_zero_not_a_partial_score(fn):
+    """A 3-dim and a 5-dim vector must never be scored via a truncated zip."""
+    a = [1.0, 1.0, 1.0]
+    b = [1.0, 1.0, 1.0, 1.0, 1.0]
+    assert fn(a, b) == 0.0
+    assert fn(b, a) == 0.0
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [vault_ops._cosine, vault_ops._dot, ss.cosine],
+    ids=["vault_ops._cosine", "vault_ops._dot", "semantic_search.cosine"],
+)
+def test_equal_length_vectors_still_score_normally(fn):
+    """strict=True must not change behaviour for the normal, matching case."""
+    identical = [1.0, 0.0, 0.0]
+    assert fn(identical, identical) == pytest.approx(1.0)
+
+    orthogonal_a = [1.0, 0.0]
+    orthogonal_b = [0.0, 1.0]
+    assert fn(orthogonal_a, orthogonal_b) == pytest.approx(0.0)
+
+
+def test_empty_vectors_return_zero():
+    assert vault_ops._cosine([], []) == 0.0
+    assert ss.cosine([], []) == 0.0


### PR DESCRIPTION
## What this PR does

`_cosine`/`_dot` in `vault_ops.py` and `cosine()` in `scripts/eval/semantic_search.py` each already guard `len(a) != len(b)` before summing with `zip()`, so a length mismatch already returns `0.0` rather than silently scoring a truncated dot product — the failure mode described in #164 isn't currently reachable. This PR turns that guard into an enforced invariant by adding `strict=True` to all four `zip()` calls (including one at `vault_ops.py:176` over two lists built together in the same loop), so a future edit that removes the length check fails loudly instead of quietly reintroducing a plausible-but-wrong similarity score. Also adds `tests/test_vector_math.py` covering mismatched-length, equal-length, and empty-vector cases for all three functions.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [ ] 📖 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

Closes #164

## How I tested it

- Added `tests/test_vector_math.py` (7 cases): mismatched-length vectors return `0.0` for `_cosine`, `_dot`, and `semantic_search.cosine`; equal-length vectors still score correctly; empty vectors return `0.0`. All pass.
- Ran the existing suites touching these paths (`test_mcp_vault_ops_safety.py`, `test_index_robustness.py`, `test_ranking_quality.py`, `test_search_cap.py`, `test_freshness.py`) — all pass, no regressions.
- `ruff check --select B905` on both files: clean.