### PR TITLE
Replace remaining os.path calls with pathlib and gate PTH #168

### DIFF
--- a/integrations/obsidian-mcp-server/live_test.py
+++ b/integrations/obsidian-mcp-server/live_test.py
@@ -15,8 +15,8 @@ also writes one test note to the vault's Inbox/.
 import asyncio
 import json
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client

--- a/integrations/obsidian-mcp-server/live_test.py
+++ b/integrations/obsidian-mcp-server/live_test.py
@@ -15,13 +15,13 @@ also writes one test note to the vault's Inbox/.
 import asyncio
 import json
 import os
+from pathlib import Path
 import sys
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-SERVER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "server.py")
-
+SERVER = (Path(__file__).parent / "server.py").as_posix()
 
 async def main(query: str, do_save: bool) -> None:
     vault = os.environ.get("OBSIDIAN_VAULT_PATH", "").strip()

--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -22,7 +22,6 @@ from pathlib import Path
 # launches us from.
 sys.path.insert(0, Path(__file__).parent.as_posix())
 
-
 import vault_ops  # noqa: E402
 from mcp.server.fastmcp import FastMCP  # noqa: E402
 

--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -15,12 +15,15 @@ or wire it into a client's MCP config (see README.md).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import os
 import sys
 
+
 # Make `vault_ops` importable regardless of the working directory the client
 # launches us from.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, Path(__file__).parent.as_posix())
+
 
 import vault_ops  # noqa: E402
 from mcp.server.fastmcp import FastMCP  # noqa: E402

--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -15,10 +15,8 @@ or wire it into a client's MCP config (see README.md).
 from __future__ import annotations
 
 import json
-from pathlib import Path
-import os
 import sys
-
+from pathlib import Path
 
 # Make `vault_ops` importable regardless of the working directory the client
 # launches us from.

--- a/integrations/obsidian-mcp-server/vault_ops.py
+++ b/integrations/obsidian-mcp-server/vault_ops.py
@@ -1059,11 +1059,11 @@ def _write_atomic(path: Path, text: str) -> None:
         with _os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
             fh.write(text)
         if keep_mode is not None:
-           Path(tmp).chmod(keep_mode)
+            Path(tmp).chmod(keep_mode)
         Path(tmp).replace(path)
     except BaseException:
         try:
-         Path(tmp).unlink()
+            Path(tmp).unlink()
         except OSError:
             pass
         raise

--- a/integrations/obsidian-mcp-server/vault_ops.py
+++ b/integrations/obsidian-mcp-server/vault_ops.py
@@ -1059,11 +1059,11 @@ def _write_atomic(path: Path, text: str) -> None:
         with _os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
             fh.write(text)
         if keep_mode is not None:
-            _os.chmod(tmp, keep_mode)
-        _os.replace(tmp, path)
+           Path(tmp).chmod(keep_mode)
+        Path(tmp).replace(path)
     except BaseException:
         try:
-            _os.unlink(tmp)
+         Path(tmp).unlink()
         except OSError:
             pass
         raise

--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -125,7 +125,6 @@ def download(file_id):
     return data, pathlib.Path(path).suffix.lower()
 
 
-
 def transcribe(file_id):
     audio, suffix = download(file_id)
     suffix = suffix or ".oga"

--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -122,7 +122,8 @@ def download(file_id):
     info = tg("getFile", file_id=file_id)
     path = info["result"]["file_path"]
     data = requests.get(f"{FILE_API}/{path}", timeout=120).content
-    return data, os.path.splitext(path)[1].lower()
+    return data, pathlib.Path(path).suffix.lower()
+
 
 
 def transcribe(file_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,3 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["F", "I", "PTH"]
 
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,6 @@ target-version = "py310"
 #   E731  lambda assignment. Used intentionally in research/lib/config.py.
 # Widening this list means fixing the backlog first, not adding a noqa sweep.
 [tool.ruff.lint]
-select = ["F","I"]
+select = ["F", "I", "PTH"]
+
+

--- a/scripts/export_okf.py
+++ b/scripts/export_okf.py
@@ -197,7 +197,7 @@ def main():
     if not vault.is_dir():
         print(f"vault not found: {vault}", file=sys.stderr)
         sys.exit(1)
-    out = (vault / args.out) if not os.path.isabs(args.out) else pathlib.Path(args.out)
+    out = (vault / args.out) if not pathlib.Path(args.out).is_absolute() else pathlib.Path(args.out)
 
     # 1) collect notes (relative path -> (src_file, fm, body, malformed))
     notes = {}

--- a/scripts/note_io.py
+++ b/scripts/note_io.py
@@ -43,7 +43,7 @@ def write_exact(path: Path, text: str) -> None:
     data = text.encode("utf-8")
     directory = path.parent
     try:
-        keep_mode = stat_mod.S_IMODE(os.stat(path).st_mode)
+       keep_mode = stat_mod.S_IMODE(Path(path).stat().st_mode)
     except OSError:
         keep_mode = None  # new file: let the umask decide, as write_bytes would have
 
@@ -57,14 +57,14 @@ def write_exact(path: Path, text: str) -> None:
             except OSError:
                 pass  # durability is best-effort; the atomic rename is not
         if keep_mode is not None:
-            os.chmod(tmp, keep_mode)
-        os.replace(tmp, path)
+            Path(tmp).chmod(keep_mode)
+        Path(tmp).replace(path)
     except BaseException:
         # Interrupted or failed before the rename: the original is untouched. Drop
         # the temp so a half-written file never lingers in the vault, then re-raise.
         # BaseException (not Exception) so a Ctrl-C mid-write still cleans up.
         try:
-            os.unlink(tmp)
+            Path(tmp).unlink()
         except OSError:
             pass
         raise

--- a/scripts/note_io.py
+++ b/scripts/note_io.py
@@ -43,7 +43,7 @@ def write_exact(path: Path, text: str) -> None:
     data = text.encode("utf-8")
     directory = path.parent
     try:
-       keep_mode = stat_mod.S_IMODE(Path(path).stat().st_mode)
+        keep_mode = stat_mod.S_IMODE(Path(path).stat().st_mode)
     except OSError:
         keep_mode = None  # new file: let the umask decide, as write_bytes would have
 

--- a/scripts/research/lib/cache.py
+++ b/scripts/research/lib/cache.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import time
 from pathlib import Path
 from typing import Any
 
 
 def _cache_dir() -> Path:
-    p = Path(os.path.expanduser("~/.cache/obsidian-second-brain/research"))
+    p = Path("~/.cache/obsidian-second-brain/research").expanduser()
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/scripts/research/lib/podcast.py
+++ b/scripts/research/lib/podcast.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -380,7 +381,7 @@ def transcribe_via_whisper(audio_url: str, max_bytes: int = 25 * 1024 * 1024) ->
                     bytes_written += len(chunk)
                     if bytes_written > max_bytes:
                         tmp.close()
-                        os.unlink(tmp.name)
+                        Path(tmp.name).unlink()
                         print(
                             f"[podcast whisper: audio exceeds {max_bytes // (1024*1024)} MB while streaming]",
                             file=sys.stderr,
@@ -394,7 +395,7 @@ def transcribe_via_whisper(audio_url: str, max_bytes: int = 25 * 1024 * 1024) ->
 
     try:
         client = OpenAI(api_key=key)
-        with open(tmp_path, "rb") as f:
+        with Path(tmp_path).open("rb") as f:
             result = client.audio.transcriptions.create(
                 model="whisper-1",
                 file=f,
@@ -413,7 +414,7 @@ def transcribe_via_whisper(audio_url: str, max_bytes: int = 25 * 1024 * 1024) ->
         return None
     finally:
         try:
-            os.unlink(tmp_path)
+            Path(tmp_path).unlink()
         except OSError:
             pass
 

--- a/scripts/research/notebooklm.py
+++ b/scripts/research/notebooklm.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import shutil
 import sys
 import tempfile
 import time
 from datetime import datetime
+from pathlib import Path
 
 from google import genai
 from google.genai import types
@@ -168,7 +168,7 @@ def upload_and_wait(client: genai.Client, store_name: str, hit: dict) -> None:
             operation = client.operations.get(operation)
     finally:
         try:
-            os.unlink(tmp_path)
+            Path(tmp_path).unlink()
         except OSError:
             pass
 

--- a/scripts/star_prompt.py
+++ b/scripts/star_prompt.py
@@ -57,7 +57,7 @@ def _claim_once(marker: Path) -> bool:
     """
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
-        with open(marker, "x", encoding="utf-8") as fh:
+        with Path(marker).open("x", encoding="utf-8") as fh:
             fh.write("shown\n")
         return True
     except FileExistsError:

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -26,7 +26,7 @@ def _load(relpath: str):
 
 
 def _pyproject_version() -> str:
-    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
         return tomllib.load(f)["project"]["version"]
 
 


### PR DESCRIPTION
## What this PR does

Converts the remaining `os.path` calls to `pathlib` equivalents across the repo (vault_ops.py, note_io.py, podcast.py, notebooklm.py, star_prompt.py, export_okf.py, cache.py, test_plugin_manifest.py) and adds `PTH` to the gated ruff rule set in `pyproject.toml`, alongside the existing `F` and `I` rules.

## Type of change

- [x] 🧹 Refactor / cleanup

## Related issues

Closes #168

## How I tested it

Ran `uv run --with ruff ruff check .` — passes clean with F/I/PTH all gated. Ran `uv run pytest -q` — one pre-existing failure (`test_write_preserves_mode`) also fails on unmodified `main` on Windows (permission bits aren't preserved the same way as POSIX), confirmed by testing against the original code, so it's unrelated to this change.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
