### PR TITLE
Fix re-raises dropping original tracebacks

### DIFF
--- a/integrations/telegram-journal/telegram_journal.py
+++ b/integrations/telegram-journal/telegram_journal.py
@@ -166,9 +166,9 @@ def transcribe_local(audio, suffix):
         except FileNotFoundError:
             raise RuntimeError(
                 f"local transcription needs the '{WHISPER_BIN}' CLI - "
-                "pip install openai-whisper (and install ffmpeg), or set WHISPER_BIN")
+                "pip install openai-whisper (and install ffmpeg), or set WHISPER_BIN") from None
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"whisper failed: {(e.stderr or '').strip()[-300:]}")
+            raise RuntimeError(f"whisper failed: {(e.stderr or '').strip()[-300:]}") from e
         out = pathlib.Path(tmp) / f"{src.stem}.txt"
         return out.read_text().strip() if out.exists() else ""
 

--- a/scripts/research/lib/podcast.py
+++ b/scripts/research/lib/podcast.py
@@ -150,10 +150,10 @@ def parse_feed(
     """Parse an RSS feed and return episode metadata + audio URL + show-notes + transcript-tag-url."""
     try:
         import feedparser
-    except ImportError:
+    except ImportError as e:
         raise RuntimeError(
             "feedparser is required. Install with: uv sync (or pip install feedparser)"
-        )
+        ) from e
     parsed = feedparser.parse(feed_url)
     if parsed.bozo and not parsed.entries:
         raise ValueError(f"Could not parse feed at {feed_url}: {parsed.bozo_exception}")

--- a/scripts/research/lib/video_frames.py
+++ b/scripts/research/lib/video_frames.py
@@ -70,7 +70,7 @@ def download_video(url: str, out_dir: Path) -> dict:
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                        check=False, timeout=600)
     except subprocess.TimeoutExpired as e:
-        raise FrameError(f"yt-dlp timed out after 600s downloading {url}") from None
+        raise FrameError(f"yt-dlp timed out after 600s downloading {url}") from e
 
     video = _pick_video(out_dir)
     if video is None:

--- a/scripts/research/lib/video_frames.py
+++ b/scripts/research/lib/video_frames.py
@@ -69,8 +69,8 @@ def download_video(url: str, out_dir: Path) -> dict:
     try:
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                        check=False, timeout=600)
-    except subprocess.TimeoutExpired:
-        raise FrameError(f"yt-dlp timed out after 600s downloading {url}")
+    except subprocess.TimeoutExpired as e:
+        raise FrameError(f"yt-dlp timed out after 600s downloading {url}") from None
 
     video = _pick_video(out_dir)
     if video is None:


### PR DESCRIPTION
Bare `raise X(...)` inside `except` implicitly sets `__context__`, so Python shows "During handling of the above exception..." — reading like a bug in the error handling itself.

Each site now uses `from e` or `from None` based on whether the original exception holds information the replacement message doesn't already cover.

<!-- Thanks for contributing! A few quick checks make it more likely your PR ships fast. -->

## What this PR does

telegram_journal.py — FileNotFoundError → from None
The message already says exactly what's missing and how to install it. The FileNotFoundError has no additional content (no stderr, no useful context), so chaining it would just be noise.

telegram_journal.py — CalledProcessError → from e
The message truncates stderr to the last 300 characters, which can cut off the most informative part if the output is long (the truncation is from the tail, and the error summary is often at the start). Also, the command depends on runtime configuration (WHISPER_LOCAL_MODEL, WHISPER_HINT) not visible in the static code. from e preserves the full stderr, returncode, and exact command for debugging.

podcast.py — ImportError → from e
The mere existence of the try/except implies the environment doesn't guarantee feedparser is installed (otherwise the block wouldn't exist). That leaves room for variants of ImportError not covered by the message (wrong venv, incomplete sync, etc.), so it's worth preserving the original exception.

video_frames.py — TimeoutExpired → from None
Unlike the previous case, there's no real information loss here: stdout/stderr are explicitly discarded (DEVNULL), so TimeoutExpired carries no captured content, and the only extra data (e.cmd) is a static literal already visible a few lines above in the code itself. The replacement message is as informative as the original.

General criterion applied: from None when the replacement message is strictly more informative than the original exception; from e when the message summarizes, truncates, or interprets a likely cause, and the full object retains diagnostic value as a fallback.

<!-- One or two sentences. What changed and why. -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [ ] 📚 Documentation update
- [x] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

<!-- "Closes #123" or "Related to #456". If none, write "n/a". -->

Closes #165 

## How I tested it

<!-- Be specific. "Ran /obsidian-save with a 200-line conversation, verified 5 notes were created in the right folders." -->

I ran ruff check . --select B904 and all checks passed
