### PR TITLE
Claim cluade-code platform ownership

### DIFF
--- a/adapters/OWNERS.md
+++ b/adapters/OWNERS.md
@@ -18,7 +18,7 @@ So platform ownership is open. A platform owner is the person who would notice.
 | Platform | Owner | Previously contributed |
 |---|---|---|
 | agent-skills | unclaimed | |
-| claude-code | unclaimed | [@MPZ-00](https://github.com/MPZ-00) |
+| claude-code | [@born-in-autumn](https://github.com/born-in-autumn) | [@MPZ-00](https://github.com/MPZ-00) |
 | codex-cli | unclaimed | [@Litash](https://github.com/Litash), [@MPZ-00](https://github.com/MPZ-00) |
 | gemini-cli | unclaimed | [@MPZ-00](https://github.com/MPZ-00) |
 | hermes | unclaimed | [@Litash](https://github.com/Litash) |


### PR DESCRIPTION
## Summary
- Claim the `claude-code` row in `adapters/OWNERS.md`, as discussed in #171.

## Test plan
- [x] Diff is a one-line Owner update only (`unclaimed` → `@born-in-autumn`)
- [x] `<!-- owners:start -->` / `<!-- owners:end -->` markers preserved
- [ ] CI green