### PR TITLE
Fix duplicate and broken-link checks on non-Latin and imported vaults

### DIFF
--- a/scripts/vault_health.py
+++ b/scripts/vault_health.py
@@ -270,12 +270,28 @@ def load_vault(vault: Path, excludes=None, only: str | None = None) -> dict:
 # duplicate, so they are exempt from duplicate detection (issue #82).
 DATED_SERIES_FOLDERS = {"daily", "logs", "dev logs", "reviews"}
 
+# Minimum normalized-title length for the truncated-title pass (see
+# _truncated_title_groups). Short titles are prefixes of each other by accident
+# ("api" prefixes "api keys"); long ones are not.
+_TRUNC_TITLE_MIN_LEN = 20
+
 
 def _norm_title(stem: str) -> str:
     """Normalize a filename stem to a comparable title. Keeps digits and dates -
     the old version stripped ISO dates, which collapsed every dated note in a
-    series onto one bucket and flagged them all as duplicates (issue #82)."""
-    norm = re.sub(r"[^a-z0-9 ]", " ", stem.lower())
+    series onto one bucket and flagged them all as duplicates (issue #82).
+
+    Unicode-aware by necessity: the class must NOT be spelled [^a-z0-9 ], which
+    deletes every non-Latin letter. Measured on a Ukrainian/Russian vault
+    (591 notes, 2026-07): "Зустріч команди 1" and "Огляд кварталу 1"
+    both normalized to "1", and any title carrying a Latin fragment collapsed
+    onto that fragment ("Огляд ринку та KPI" -> "kpi", "Підсумки за 2024" -> "2024"). 12 of the 14 reported duplicates were unrelated notes grouped this
+    way. str.isalnum() is script-agnostic, so Cyrillic, Greek, CJK and Latin
+    titles all keep their letters.
+    """
+    norm = "".join(
+        ch if (ch.isalnum() or ch.isspace()) else " " for ch in _nfc(stem).lower()
+    )
     return re.sub(r"\s+", " ", norm).strip()
 
 
@@ -300,6 +316,58 @@ def _max_pairwise_similarity(notes: dict, files: list) -> float:
     return best
 
 
+def _truncated_title_groups(candidates: list) -> list:
+    """Group notes whose title is a truncation of another note's title.
+
+    Exporters that derive a filename from a title cut it at a fixed length, so
+    one source item can land twice under names that differ only in the tail:
+    "...про управління компанією.md" and "...про управління компанією та.md" are one
+    book stored twice. Exact-title grouping cannot see that.
+
+    Strict prefix, not fuzzy similarity. That distinction was measured, not
+    assumed: a 0.90 difflib ratio on normalized titles rated the numbered series
+    "Огляд кварталу 1"/"2" at 0.95 and grouped them as duplicates, while a
+    genuine truncation pair scored 0.98 - the two are indistinguishable by ratio.
+    Body similarity cannot break the tie either: the false pair scored 1.00
+    (both are short stubs) and the true pair 0.40. A strict prefix separates them
+    cleanly, because a trailing "1" vs "2" is never a prefix of the other.
+
+    `candidates` is a list of (norm_title, rel). Returns lists of rels.
+    """
+    by_folder = defaultdict(list)
+    for norm, rel in candidates:
+        by_folder[rel.rsplit("/", 1)[0] if "/" in rel else ""].append((norm, rel))
+
+    groups = []
+    for bucket in by_folder.values():
+        if len(bucket) < 2:
+            continue
+        # Shortest first, so a truncated stem is compared as the prefix.
+        bucket.sort(key=lambda pair: len(pair[0]))
+        used = set()
+        for i, (norm_a, rel_a) in enumerate(bucket):
+            if rel_a in used:
+                continue
+            group = [rel_a]
+            for norm_b, rel_b in bucket[i + 1:]:
+                if rel_b in used or norm_b == norm_a:
+                    continue
+                if not norm_b.startswith(norm_a):
+                    continue
+                # "Notes" vs "Notes 2" is a numbered series, not a truncated
+                # title: an exporter cutting a title never appends a bare
+                # number. Requiring the tail to carry a word keeps parts of a
+                # series out of the duplicate report.
+                if not norm_b[len(norm_a):].strip().strip("0123456789 ."):
+                    continue
+                group.append(rel_b)
+                used.add(rel_b)
+            if len(group) > 1:
+                used.add(rel_a)
+                groups.append(group)
+    return groups
+
+
 def check_duplicates(notes: dict) -> list:
     issues = []
     groups = defaultdict(list)
@@ -321,6 +389,29 @@ def check_duplicates(notes: dict) -> list:
             "severity": "warning" if similar else "info",
             "message": (
                 f"{'Likely duplicates' if similar else 'Same title, different content'}: {norm!r}"
+            ),
+            "files": files,
+        })
+
+    # Second pass: one title is a truncation of another, which exact grouping
+    # cannot see. Severity still follows the body signal - a truncated title
+    # says the pair came from one source, the bodies say whether it is a copy.
+    already = {rel for files in groups.values() if len(files) > 1 for rel in files}
+    candidates = [
+        (norm, rel)
+        for norm, files in groups.items()
+        for rel in files
+        if rel not in already and len(norm) >= _TRUNC_TITLE_MIN_LEN
+    ]
+    for files in _truncated_title_groups(candidates):
+        similar = _max_pairwise_similarity(notes, files) >= 0.6
+        issues.append({
+            "type": "duplicate",
+            "severity": "warning" if similar else "info",
+            "message": (
+                "Truncated title of another note"
+                f"{' with matching content' if similar else ''}: "
+                f"{[Path(f).stem for f in files]}"
             ),
             "files": files,
         })
@@ -603,6 +694,19 @@ def _normalize_dashes(s: str) -> str:
     return s.replace(_EM_DASH, "-").replace(_EN_DASH, "-")
 
 
+# Suffixes that mean "this link points at an attachment, not at a note yet to be
+# written". A missing note is a knowledge gap worth writing; a missing attachment
+# is an import-cleanup task. Reporting both under one label hides the first
+# inside the second - on the vault this was found on, 43 of 43 "wanted notes"
+# were attachment links, so a genuine knowledge gap would have been invisible.
+_ASSET_SUFFIXES = (
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".tiff", ".heic",
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".odt", ".rtf",
+    ".zip", ".gz", ".tar", ".7z", ".xmind", ".mp3", ".mp4", ".mov", ".wav",
+    ".m4a", ".webm", ".epub", ".mobi",
+)
+
+
 def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
     """Find links whose target note does not exist yet. These are NOT errors -
     in a wiki-style vault you link a thing the moment you mention it, long before
@@ -662,12 +766,24 @@ def check_wanted_notes(notes: dict, vault: Path, excludes=None) -> list:
                 or link_dash_norm in all_stems_dash_norm
                 or _nfc(link).lower() in all_files
                 or f"{_nfc(link).lower()}.md" in all_files
+                # Path-form links to assets. Notion exports write
+                # [[Attachments Folder/Screenshot_11.png]], where the folder
+                # segment is relative to the *note*, not to the vault root - so
+                # the full-path lookup above can never match. index_vault_files()
+                # already indexes bare filenames (and Obsidian itself resolves a
+                # link by name), so the last path component has to be checked
+                # too. Without this line every imported attachment link is
+                # reported as a wanted note: 43 of 43 on the vault where this
+                # was found, with all 43 files present on disk.
+                or link_stem in all_files
+                or link_dash_norm in all_files
             )
             if not resolved:
                 potential_folder = vault / link
                 if not potential_folder.is_dir():
+                    is_asset = link_name.lower().endswith(_ASSET_SUFFIXES)
                     issues.append({
-                        "type": "wanted_note",
+                        "type": "missing_attachment" if is_asset else "wanted_note",
                         "severity": "info",
                         # A '[' inside the captured name means the real filename
                         # contains brackets and the regex capture stopped early -
@@ -706,6 +822,11 @@ def run_health_check(vault: Path) -> dict:
     notes = load_vault(vault, excludes)
     print(f"   Found {len(notes)} notes\n", file=sys.stderr)
 
+    # Wanted notes and missing attachments come out of one scan but mean
+    # different things and get counted separately: a missing note is a gap to
+    # write, a missing attachment is import cleanup.
+    link_gaps = check_wanted_notes(notes, vault, excludes)
+
     checks = [
         ("Duplicates", check_duplicates(notes)),
         ("Orphans", check_orphans(notes)),
@@ -713,7 +834,9 @@ def run_health_check(vault: Path) -> dict:
         ("Code-fence-wrapped notes", check_code_fence_wrapped(notes)),
         ("Missing frontmatter", check_missing_frontmatter(notes)),
         ("Empty folders", check_empty_folders(vault, excludes)),
-        ("Wanted notes", check_wanted_notes(notes, vault, excludes)),
+        ("Wanted notes", [i for i in link_gaps if i["type"] == "wanted_note"]),
+        ("Missing attachments",
+         [i for i in link_gaps if i["type"] == "missing_attachment"]),
         ("Template leftovers", check_template_leftovers(notes)),
         ("Semantic index coverage", check_semantic_index(vault, notes)),
     ]

--- a/tests/test_vault_health_precision.py
+++ b/tests/test_vault_health_precision.py
@@ -109,3 +109,86 @@ def test_inline_aliases_resolve_links(tmp_path):
 
     wanted = _issues(_health(vault), "wanted_note")
     assert wanted == [], wanted
+
+
+def test_non_latin_titles_are_not_collapsed_to_their_latin_fragments(tmp_path):
+    """[^a-z0-9 ] deleted every Cyrillic letter, so unrelated notes collided.
+
+    Found on a 591-note Ukrainian/Russian vault: 'Огляд ринку та KPI' normalized to
+    'kpi' and 'Зустріч команди 1' to '1', which grouped notes sharing
+    nothing but a stray Latin fragment. 12 of 14 reported duplicates were noise.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Огляд ринку та KPI.md").write_text("Про мотивацію.\n", encoding="utf-8")
+    (vault / "Правила роботи та KPI.md").write_text("Про роад-мап.\n", encoding="utf-8")
+    (vault / "Зустріч команди 1.md").write_text("Про навушники.\n", encoding="utf-8")
+    (vault / "Огляд кварталу 1.md").write_text("Про продажі.\n", encoding="utf-8")
+
+    dupes = _issues(_health(vault), "duplicate")
+    assert dupes == [], f"unrelated non-Latin titles reported as duplicates: {dupes}"
+
+
+def test_numbered_series_is_not_reported_as_a_truncated_title(tmp_path):
+    """'X 1' / 'X 2' are parts of a series; neither is a truncation of the other.
+
+    Measured: difflib rates them 0.95 and their bodies 1.00 (both are stubs), so
+    neither a title ratio nor a content gate can separate them from a real
+    truncation pair - only the strict-prefix rule can.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    for part in (1, 2):
+        (vault / f"Довга назва серії матеріалів {part}.md").write_text(
+            "Коротка заглушка.\n", encoding="utf-8")
+
+    dupes = _issues(_health(vault), "duplicate")
+    assert dupes == [], f"numbered series reported as duplicates: {dupes}"
+
+
+def test_export_truncated_title_is_reported(tmp_path):
+    """An exporter cutting one title at two lengths stores one item twice."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Довга назва книги про управління компанією.md").write_text(
+        "Перший запис.\n", encoding="utf-8")
+    (vault / "Довга назва книги про управління компанією та.md").write_text(
+        "Другий запис, інший текст.\n", encoding="utf-8")
+
+    dupes = _issues(_health(vault), "duplicate")
+    assert len(dupes) == 1, f"expected the truncation pair to be reported, got {dupes}"
+    assert len(dupes[0]["files"]) == 2
+
+
+def test_attachment_link_resolves_by_bare_filename(tmp_path):
+    """[[Folder/file.png]] from a Notion export must not be reported as missing.
+
+    The folder segment is relative to the note, not the vault root, so the
+    full-path lookup never matched and every imported attachment link was
+    reported as a wanted note - 43 of 43 on the vault where this was found,
+    with all 43 files present on disk.
+    """
+    vault = tmp_path / "vault"
+    (vault / "Проєкт" / "Вкладення").mkdir(parents=True)
+    (vault / "Проєкт" / "Вкладення" / "Screenshot_11.png").write_bytes(b"\x89PNG\r\n")
+    (vault / "Проєкт" / "Нотатка.md").write_text(
+        "Дивись [[Вкладення/Screenshot_11.png]].\n", encoding="utf-8")
+
+    payload = _health(vault)
+    assert _issues(payload, "wanted_note") == []
+    assert _issues(payload, "missing_attachment") == []
+
+
+def test_absent_attachment_is_reported_separately_from_a_wanted_note(tmp_path):
+    """A gap to write and an import to clean up are different work items."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Нотатка.md").write_text(
+        "Картинка [[diagram.png]] і нотатка [[Ще не написана нотатка]].\n",
+        encoding="utf-8")
+
+    payload = _health(vault)
+    wanted = _issues(payload, "wanted_note")
+    missing = _issues(payload, "missing_attachment")
+    assert len(wanted) == 1 and "Ще не написана" in wanted[0]["message"]
+    assert len(missing) == 1 and "diagram.png" in missing[0]["message"]


### PR DESCRIPTION
Found by running `vault_health.py` over a 591-note Ukrainian/Russian vault. Two defects, both loud enough to bury the real findings — and the first also hides them outright.

## 1. `_norm_title` deletes every non-Latin letter

```python
norm = re.sub(r"[^a-z0-9 ]", " ", stem.lower())
```

On any non-Latin vault this is near-total erasure. A Cyrillic title carrying a stray Latin fragment collapses onto that fragment, and one ending in a digit collapses to the digit alone:

| title | normalized |
|---|---|
| `<Cyrillic words> та KPI` | `kpi` |
| `<other Cyrillic words> та KPI` | `kpi` |
| `<Cyrillic words> 1` | `1` |

So unrelated notes get grouped as duplicates: **12 of 14 reports on that vault were noise.** The same erasure also *hid* two genuine duplicate pairs — they only surfaced once titles survived normalization. `str.isalnum()` is script-agnostic and keeps Cyrillic, Greek and CJK titles intact.

## 2. A link's bare filename is never checked against the file index

`index_vault_files()` already indexes bare filenames (it explicitly adds `f.name`), but `check_wanted_notes` only ever looks up the *full* link path in it. Notion exports write `[[Folder/file.png]]` where the folder segment is relative to the **note**, not the vault root — so the full-path lookup can never match.

Result: **every imported attachment link is reported as a missing note — 43 of 43 on that vault, with all 43 files present on disk.** One added condition fixes it, matching how Obsidian itself resolves a link by name.

This also splits `missing_attachment` from `wanted_note` as its own type and count. Import cleanup and a knowledge gap are different work items, and merging them hides the rarer, more useful one: on that vault a genuine wanted note would have been invisible inside 43 attachment links.

## 3. Truncated titles (new pass)

Exact-title grouping cannot see an exporter that cuts one title at two lengths, so one source item stored twice stays invisible. Added a pass for it.

It uses a **strict prefix, not fuzzy similarity** — that choice was measured, not assumed:

| pair | difflib ratio | body similarity |
|---|---|---|
| numbered series (`<title> 1` / `<title> 2`) | 0.95 | 1.00 |
| genuine truncation pair | 0.98 | 0.40 |

Neither signal separates them, and body similarity actively inverts them. A strict prefix does separate them cleanly, since a trailing `1` is never a prefix of `2`. A bare trailing number is excluded so numbered series stay out of the report.

## Verification

- All 556 existing tests pass; 5 regression tests added (561 total).
- 3 of the 5 fail without this change (verified by reverting the source and re-running); the other 2 pin behaviour the old code produced only by accident.
- Test fixtures use synthetic titles, not real note names.

Net effect on the vault it was found on: duplicates 14 → 9 (all genuine, including 2 previously hidden), wanted notes 43 → 0.
