### PR TITLE
Fix /notebooklm and /research-deep vault_scan on non-wiki-style vaults

### DIFF
--- a/scripts/research/notebooklm.py
+++ b/scripts/research/notebooklm.py
@@ -32,7 +32,6 @@ from google.genai import types
 
 from .lib.config import NOTEBOOKLM_MODEL, VAULT_PATH, get_required
 
-VAULT_SCAN_DIRS = ["wiki", "Research", "Knowledge", "Projects", "Ideas"]
 MAX_BUNDLE_NOTES = 12
 NOTEBOOKLM_DIR = VAULT_PATH / "Research" / "NotebookLM"
 
@@ -44,12 +43,19 @@ def slugify(text: str) -> str:
     return text[:80]
 
 
+def _vault_scan_dirs() -> list[str]:
+    """Top-level vault folders that actually exist - never a hardcoded name (folder-map.md)."""
+    if not VAULT_PATH.exists():
+        return []
+    return [p.name for p in VAULT_PATH.iterdir() if p.is_dir() and not p.name.startswith(".")]
+
+
 def vault_scan(topic: str) -> list[dict]:
     keywords = [w for w in re.split(r"\s+", topic.lower()) if len(w) > 2]
     if not keywords:
         return []
     hits: list[dict] = []
-    for sub in VAULT_SCAN_DIRS:
+    for sub in _vault_scan_dirs():
         root = VAULT_PATH / sub
         if not root.exists():
             continue

--- a/scripts/research/research_deep.py
+++ b/scripts/research/research_deep.py
@@ -25,9 +25,15 @@ from pathlib import Path
 
 from .lib.config import VAULT_PATH
 
-VAULT_SCAN_DIRS = ["wiki", "Research", "Knowledge", "Projects", "Ideas"]
 MAX_BASELINE_NOTES = 8
 MAX_BASELINE_CHARS_PER_NOTE = 1500
+
+
+def _vault_scan_dirs() -> list[str]:
+    """Top-level vault folders that actually exist - never a hardcoded name (folder-map.md)."""
+    if not VAULT_PATH.exists():
+        return []
+    return [p.name for p in VAULT_PATH.iterdir() if p.is_dir() and not p.name.startswith(".")]
 
 
 def vault_scan(topic: str) -> list[dict]:
@@ -36,7 +42,7 @@ def vault_scan(topic: str) -> list[dict]:
     if not keywords:
         return []
     hits: list[dict] = []
-    for sub in VAULT_SCAN_DIRS:
+    for sub in _vault_scan_dirs():
         root = VAULT_PATH / sub
         if not root.exists():
             continue


### PR DESCRIPTION
## Summary
- `VAULT_SCAN_DIRS` in both `scripts/research/notebooklm.py` and `scripts/research/research_deep.py` hardcoded English/wiki-style folder names (`wiki`, `Research`, `Knowledge`, `Projects`, `Ideas`).
- Any vault that doesn't use those exact folder names - e.g. an Obsidian-style vault in another language (`Projets/`, `Ressources/`) - matches none of them, so `vault_scan()` silently returns zero hits for every topic and `/notebooklm` always fails with `no vault notes match topic '<topic>'`.
- `references/folder-map.md` already documents the fix for this class of bug: "when a command greps everywhere... enumerate whatever top-level note folders actually exist in the vault rather than a fixed list." Both scripts appear to have been missed by the folder-map sweep mentioned in the changelog.

## Fix
Replaced the hardcoded list with a shared `_vault_scan_dirs()` helper in each file that lists the actual top-level directories under `VAULT_PATH` (excluding dot-dirs) at scan time.

## Test plan
- [x] Ran `/notebooklm --topic "<topic>"` against a French Obsidian-style vault (`Projets/`, `Ressources/`, no `wiki/`/`Projects/`/`Knowledge/`/`Ideas/`) before the fix: 0 hits every time.
- [x] Same command after the fix: correctly scans the vault's real top-level folders and returns relevant notes.
- [x] `git diff` reviewed for no behavior change on a wiki-style or English Obsidian-style vault (folder names present are still scanned the same way, just discovered dynamically instead of hardcoded).