### PR TITLE
Pin mcp<2 in obsidian-mcp-server launch commands

### DIFF
--- a/integrations/obsidian-mcp-server/README.md
+++ b/integrations/obsidian-mcp-server/README.md
@@ -45,8 +45,11 @@ Requires the vault path in the environment and the `mcp` package:
 
 ```bash
 export OBSIDIAN_VAULT_PATH="/path/to/your/vault"
-uv run --with mcp python integrations/obsidian-mcp-server/server.py
+uv run --with "mcp<2" python integrations/obsidian-mcp-server/server.py
 ```
+
+Pin below 2.0: `mcp` 2.0.0 renamed `mcp.server.fastmcp.FastMCP` to
+`mcp.server.mcpserver.MCPServer`, which breaks `server.py`'s import.
 
 ## Wire it into a client
 
@@ -57,7 +60,7 @@ Hermes Agent and most MCP clients take a launch command. Example client config e
   "mcpServers": {
     "obsidian-second-brain": {
       "command": "uv",
-      "args": ["run", "--with", "mcp", "python", "/abs/path/integrations/obsidian-mcp-server/server.py"],
+      "args": ["run", "--with", "mcp<2", "python", "/abs/path/integrations/obsidian-mcp-server/server.py"],
       "env": { "OBSIDIAN_VAULT_PATH": "/path/to/your/vault" }
     }
   }
@@ -72,9 +75,9 @@ For Hermes specifically, add the server to its MCP config; Hermes picks the tool
 
 ```bash
 # read-only (safe against a real vault)
-OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with mcp python live_test.py "your query"
+OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with "mcp<2" python live_test.py "your query"
 # also write one test note to Inbox/
-OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with mcp python live_test.py --save "your query"
+OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with "mcp<2" python live_test.py --save "your query"
 ```
 
 Live-test checklist:

--- a/integrations/obsidian-mcp-server/live_test.py
+++ b/integrations/obsidian-mcp-server/live_test.py
@@ -5,8 +5,8 @@ Agent / Claude Desktop / Cursor use - and exercises every tool. Proves the
 connector works end-to-end without needing Hermes itself installed.
 
 Usage:
-    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with mcp python live_test.py
-    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with mcp python live_test.py --save "query"
+    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with "mcp<2" python live_test.py
+    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with "mcp<2" python live_test.py --save "query"
 
 Without --save the run is read-only (safe against a real vault). With --save it
 also writes one test note to the vault's Inbox/.

--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -7,7 +7,10 @@ and add notes to an Obsidian vault. This is the "second brain as a tool" connect
 doorway into the knowledge vault.
 
 Run:
-    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with mcp python server.py
+    OBSIDIAN_VAULT_PATH=/path/to/vault uv run --with "mcp<2" python server.py
+
+Pinned below 2.0: mcp 2.0.0 renamed mcp.server.fastmcp.FastMCP to
+mcp.server.mcpserver.MCPServer, which breaks the import below.
 
 or wire it into a client's MCP config (see README.md).
 """


### PR DESCRIPTION
## Summary
- `mcp` 2.0.0 renamed `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer`, so the documented `uv run --with mcp python server.py` (unpinned) now crashes with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
- Pin to `mcp<2` in all launch commands (`server.py` docstring, `live_test.py` docstring, `README.md` run/testing sections and the client-config JSON example)

## Test plan
- [x] `OBSIDIAN_VAULT_PATH=<vault> uv run --with mcp python live_test.py` reproduces the crash on a fresh environment (unpinned `mcp` resolves to 2.0.0)
- [x] Same command with `--with "mcp<2"` completes the full round-trip: handshake, tool listing (10 tools), `obsidian_search`, `obsidian_read_note` against a real vault