### PR TITLE
PostCompact: say whether a run propagated anything, not just that it ran

### DIFF
--- a/hooks/obsidian-bg-agent.sh
+++ b/hooks/obsidian-bg-agent.sh
@@ -21,6 +21,11 @@
 # To disable again: clear OBSIDIAN_BG_AGENT_ENABLED (the gate below makes that enough).
 #
 # Optional:
+#   - OBSIDIAN_BG_COUNT_IGNORE is an extended regex of vault-relative paths to
+#     leave out of the completed line's files_changed count. Set it to whatever
+#     your vault regenerates on its own (boards, rollups, an index, a memory
+#     mirror), or files_changed never reaches 0 and cannot tell a no-op run
+#     apart from a productive one. Unset by default.
 #   - CLAUDE_VAULT_PROPAGATION=1 lets the origin project's CLAUDE.md steer
 #     propagation. If set, and the compacting project has a "## Vault
 #     propagation hints" section in its CLAUDE.md, that section (only) is
@@ -30,7 +35,9 @@
 # Logs:
 #   - $TMPDIR/obsidian-bg-agent-$(id -u).log - stdout/stderr, mode 0600
 #   - $VAULT/.claude-runs/YYYY-MM-DD.jsonl - one JSONL line per run outcome
-#     (early-exit reason, or starting + completed with duration and exit code)
+#     (early-exit reason, or starting + completed with duration, exit code and
+#     files_changed - see OBSIDIAN_BG_COUNT_IGNORE above, without which that
+#     count is dominated by files the vault regenerates on its own)
 
 VAULT="${OBSIDIAN_VAULT_PATH:-}"
 [[ -z "$VAULT" ]] && exit 0
@@ -53,6 +60,56 @@ mkdir -p "$RUNS_DIR" 2>/dev/null || true
 # `stat -f`; 0 if neither works so callers never divide by a missing value.
 file_mtime() {
   stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# count_changed_since <marker> - how many vault files were modified after the
+# marker file was created. Prints an integer, or returns 1 and prints nothing
+# when the count cannot be trusted, so the caller omits the field rather than
+# logging a guess.
+#
+# Why mtime and not `git status --porcelain | wc -l`: a vault under the
+# Obsidian Git plugin auto-commits on a timer, and a commit landing mid-run
+# drops the dirty count back to zero - so a status delta would report "wrote
+# nothing" for a run that wrote three notes, the precise failure this field
+# exists to prevent. A commit does not change file mtimes, so `-newer` is
+# immune to it, and it needs no git at all, which also covers vaults that are
+# not repos.
+#
+# Dot-prefixed names are pruned at every level. That drops .git, .obsidian's
+# constantly-rewritten workspace state, this hook's own .claude-runs log and
+# .claude-lock; without the prune every run reports a nonzero count and the
+# field says nothing.
+#
+# OBSIDIAN_BG_COUNT_IGNORE drops machine-generated paths from the count. It is
+# an extended regex matched against VAULT-RELATIVE paths, and it matters more
+# than it looks: the headless agent this hook spawns is a full Claude Code
+# session that loads this same plugin, so its OWN SessionStart/SessionEnd hooks
+# rebuild the task board, the rollups, the index and the memory mirror against
+# whatever OBSIDIAN_VAULT_PATH points at. Measured by pointing the hook at an
+# empty scratch vault: 3 notes written by the propagation itself, 216 files
+# written by that machinery. Without an ignore pattern a no-op run still counts
+# several files, so the field never reaches 0 and cannot mean what it says.
+# Unset by default, because the paths are a property of the vault's layout and
+# guessing them for someone else's vault would be worse than counting everything.
+count_changed_since() {
+  local marker="$1" found filtered rc
+  [[ -n "$marker" && -f "$marker" ]] || return 1
+  found=$(find "$VAULT" -name '.*' -prune -o -type f -newer "$marker" -print 2>/dev/null) || return 1
+  [[ -z "$found" ]] && { printf '0'; return 0; }
+  # Vault-relative via substr, not sed: a vault path holding regex or delimiter
+  # metacharacters cannot corrupt the match this way.
+  found=$(printf '%s\n' "$found" | awk -v n="${#VAULT}" '{ print substr($0, n + 2) }')
+  if [[ -n "${OBSIDIAN_BG_COUNT_IGNORE:-}" ]]; then
+    filtered=$(printf '%s\n' "$found" | grep -Ev "$OBSIDIAN_BG_COUNT_IGNORE"); rc=$?
+    # grep exits 1 when it filtered everything out (a real zero) and >=2 on a
+    # bad pattern. Treating those alike would turn a broken regex into a
+    # confident "wrote nothing", which is the one wrong answer this field
+    # must never give.
+    [[ $rc -ge 2 ]] && return 1
+    found="$filtered"
+  fi
+  [[ -z "$found" ]] && { printf '0'; return 0; }
+  printf '%s\n' "$found" | wc -l | tr -d ' \n'
 }
 
 # log_run <status> [key val [key val ...]]  - append one JSONL line.
@@ -203,6 +260,11 @@ INSTRUCTIONS
 
 log_run "starting" summary_chars "${#SUMMARY}" hints_chars "${#PROJECT_HINTS}"
 
+# t0 for the file-change count. Created here, immediately before the agent
+# starts, so `find -newer` against it sees exactly the run's window. mktemp
+# failing is not fatal: the count is then unavailable and the field is omitted.
+CHANGE_MARKER=$(mktemp "${TMPDIR:-/tmp}/obsidian-bg-marker-XXXXXX" 2>/dev/null || true)
+
 # Run headless agent in vault directory - async, logs to /tmp for debugging.
 # Feed the prompt via stdin, NOT as an argv element. `claude -p "$PROMPT"`
 # passes the whole prompt as one command-line argument and hits the ~32K
@@ -230,7 +292,26 @@ log_run "starting" summary_chars "${#SUMMARY}" hints_chars "${#PROJECT_HINTS}"
     -p < "$PROMPT_FILE" >> "$BG_LOG" 2>&1
   EXIT_CODE=$?
   rm -f "$PROMPT_FILE"
-  log_run "completed" duration_sec "$(( $(date +%s) - START_TIME ))" exit_code "$EXIT_CODE"
+  # files_changed answers the one question exit_code cannot: did this run
+  # propagate anything at all. Both a run that wrote three notes and a run that
+  # decided the summary held nothing new exit 0, and the prompt tells the agent
+  # to take the second path, so that is the COMMON outcome rather than an edge
+  # case - "completed, exit 0" was never evidence of a write.
+  #
+  # Read it as a direction, not an attribution: it counts every vault file
+  # touched in the window that OBSIDIAN_BG_COUNT_IGNORE did not exclude, so any
+  # other writer active at the same time still inflates it and it can never
+  # prove THIS agent wrote a given file. Zero is the trustworthy end - nothing
+  # was written, by anyone - and it only reaches zero if that ignore pattern
+  # covers what the vault regenerates on its own. Omitted entirely when
+  # unavailable, so the field is never a guess.
+  if CHANGED=$(count_changed_since "$CHANGE_MARKER"); then
+    log_run "completed" duration_sec "$(( $(date +%s) - START_TIME ))" exit_code "$EXIT_CODE" files_changed "$CHANGED"
+  else
+    log_run "completed" duration_sec "$(( $(date +%s) - START_TIME ))" exit_code "$EXIT_CODE"
+  fi
+  [[ -n "$CHANGE_MARKER" ]] && rm -f "$CHANGE_MARKER"
+  true
 ) &
 
 exit 0

--- a/hooks/postcompact.hook.example.json
+++ b/hooks/postcompact.hook.example.json
@@ -21,6 +21,19 @@
 //   3. Merge the "hooks" block below into ~/.claude/settings.json (real JSON -
 //      strip these comments), using the absolute path to your installed script.
 //
+// OPTIONAL, but read this if you want the run log to be useful:
+// OBSIDIAN_BG_COUNT_IGNORE is an extended regex of vault-relative paths left
+// out of the files_changed count on each run's "completed" line. The headless
+// agent is a full Claude Code session that loads this same skill, so its own
+// SessionStart/SessionEnd hooks rewrite whatever your vault regenerates -
+// boards, rollups, an index, a memory mirror - during every run. Without a
+// pattern the count never reaches 0, so it cannot tell a run that propagated
+// nothing from one that wrote notes. Name your generated paths, and leave the
+// folders the agent legitimately writes to (daily notes, projects) out of it:
+//      "env": {
+//        "OBSIDIAN_BG_COUNT_IGNORE": "^(index\\.md|Boards/|Rollups/)"
+//      }
+//
 // To DISABLE again: set OBSIDIAN_BG_AGENT_ENABLED to "0" (or remove it). The
 // hard gate in the script makes clearing the flag enough to render it inert,
 // even if the PostCompact hook stays registered.

--- a/tests/test_bg_agent_hook.py
+++ b/tests/test_bg_agent_hook.py
@@ -19,7 +19,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HOOK = REPO_ROOT / "hooks" / "obsidian-bg-agent.sh"
 
 
-def _run_hook(stdin: str, env_extra: dict, tmp_path: Path) -> subprocess.CompletedProcess:
+def _run_hook(stdin: str, env_extra: dict, tmp_path: Path,
+              stub_writes: list[str] | None = None) -> subprocess.CompletedProcess:
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir(exist_ok=True)
     record = tmp_path / "claude-invocation.txt"
@@ -27,15 +28,25 @@ def _run_hook(stdin: str, env_extra: dict, tmp_path: Path) -> subprocess.Complet
     # Capture args AND stdin: the prompt is fed to `claude -p` via stdin, not
     # as an argv element (avoids the ~32K Windows command-line limit), so the
     # summary now arrives on stdin rather than in "$@".
-    stub.write_text(
+    body = (
         "#!/usr/bin/env bash\n"
-        f'{{ echo "CWD=$PWD"; printf \'ARG=%s\\n\' "$@"; echo "STDIN<<<"; cat; }} > "{record}"\n',
-        encoding="utf-8",
+        f'{{ echo "CWD=$PWD"; printf \'ARG=%s\\n\' "$@"; echo "STDIN<<<"; cat; }} > "{record}"\n'
     )
+    # stub_writes names vault-relative paths the stub should create, standing in
+    # for notes the real agent would propagate. Paths, not a count: a loop over
+    # `seq 1 $n` looks equivalent but BSD seq counts DOWN when first > last, so
+    # `seq 1 0` yields "1 0" and the write-nothing case silently writes two
+    # files - which reads as a hook bug rather than a harness one.
+    for rel in stub_writes or []:
+        body += f'mkdir -p "$(dirname "$PWD/{rel}")" && printf \'stub\\n\' > "$PWD/{rel}"\n'
+    stub.write_text(body, encoding="utf-8")
     stub.chmod(0o755)
     env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}", **env_extra}
+    # Clear every var the hook reads, so a developer whose own shell has these
+    # exported does not get different results from CI.
     env.pop("OBSIDIAN_VAULT_PATH", None)
     env.pop("OBSIDIAN_BG_AGENT_ENABLED", None)
+    env.pop("OBSIDIAN_BG_COUNT_IGNORE", None)
     env.update(env_extra)
     return subprocess.run(["bash", str(HOOK)], input=stdin, env=env,
                           capture_output=True, text=True, timeout=30)
@@ -215,3 +226,87 @@ def test_launch_uses_strict_mcp_config(tmp_path):
         time.sleep(0.1)
     body = record.read_text(encoding="utf-8")
     assert "ARG=--strict-mcp-config" in body, "headless run must enforce filesystem-only MCP"
+
+
+# --- files_changed -----------------------------------------------------------
+# Without this field the completed line is identical for a run that wrote three
+# notes and a run that wrote none - and the prompt instructs the agent to exit
+# without changes when the summary holds nothing new, so the no-op is the common
+# outcome, not an edge case. exit_code 0 was never evidence of a write.
+
+def _completed_entry(vault: Path) -> dict:
+    for _ in range(50):  # appended from the async subshell
+        entries = _read_run_log(vault)
+        done = [e for e in entries if e["status"] == "completed"]
+        if done:
+            return done[-1]
+        time.sleep(0.1)
+    raise AssertionError(f"no completed entry in run log: {_read_run_log(vault)}")
+
+
+def _fire(tmp_path: Path, vault: Path, env_extra: dict, stub_writes=None):
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"isCompactSummary": True,
+                    "message": {"content": "did some work worth propagating"}}) + "\n",
+        encoding="utf-8",
+    )
+    env = {"OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1", **env_extra}
+    r = _run_hook(json.dumps({"transcript_path": str(transcript)}), env, tmp_path,
+                  stub_writes=stub_writes)
+    assert r.returncode == 0
+    return _completed_entry(vault)
+
+
+def test_files_changed_is_zero_when_the_agent_writes_nothing(tmp_path):
+    """A no-op run must be distinguishable from a productive one. Zero is the
+    load-bearing end of this field, so the hook's own .claude-runs log and lock
+    file must not leak into the count - they are dot-prefixed and pruned."""
+    vault = tmp_path / "vault"; vault.mkdir()
+    completed = _fire(tmp_path, vault, {}, stub_writes=[])
+    assert completed["files_changed"] == 0
+
+
+def test_files_changed_counts_what_the_agent_wrote(tmp_path):
+    vault = tmp_path / "vault"; vault.mkdir()
+    completed = _fire(tmp_path, vault, {},
+                      stub_writes=["Daily/2026-01-01.md", "Projects/Widget.md"])
+    # Assert the setup did what it claimed, independently of the hook: a harness
+    # that trusts its own fixture reports the fixture's bugs as the hook's.
+    assert len(list(vault.rglob("*.md"))) == 2
+    assert completed["files_changed"] == 2
+
+
+def test_files_changed_excludes_generated_paths(tmp_path):
+    """The headless agent is a full Claude Code session that loads this same
+    plugin, so its own SessionStart/SessionEnd hooks rewrite boards, rollups,
+    an index and a memory mirror during the run. Without OBSIDIAN_BG_COUNT_IGNORE
+    the count never reaches 0 and the field stops meaning anything."""
+    vault = tmp_path / "vault"; vault.mkdir()
+    completed = _fire(
+        tmp_path, vault,
+        {"OBSIDIAN_BG_COUNT_IGNORE": r"^(index\.md|Boards/)"},
+        stub_writes=["index.md", "Boards/Work.md", "Daily/2026-01-01.md"],
+    )
+    assert len(list(vault.rglob("*.md"))) == 3, "all three must exist on disk"
+    assert completed["files_changed"] == 1, "only the non-generated write counts"
+
+
+def test_files_changed_omitted_rather_than_guessed_when_the_count_fails(tmp_path):
+    """A malformed ignore pattern must not read as 'wrote nothing'. grep exits 1
+    when it filtered everything out and >=2 on a bad pattern; conflating them
+    would turn a typo into a confident, wrong zero.
+
+    Differential on purpose: the same write with a VALID pattern must produce the
+    field. Asserting only the absence would pass against any build that never
+    emits files_changed at all, which is exactly nothing."""
+    good = tmp_path / "good"; good.mkdir()
+    ok = _fire(tmp_path, good, {"OBSIDIAN_BG_COUNT_IGNORE": r"^Boards/"},
+               stub_writes=["Daily/2026-01-01.md"])
+    assert ok["files_changed"] == 1, "a valid pattern must still yield a count"
+
+    bad = tmp_path / "bad"; bad.mkdir()
+    completed = _fire(tmp_path, bad, {"OBSIDIAN_BG_COUNT_IGNORE": "^(["},
+                      stub_writes=["Daily/2026-01-01.md"])
+    assert "files_changed" not in completed, "an unavailable count must be absent, not 0"
+    assert completed["exit_code"] == 0, "the run itself must still be reported"


### PR DESCRIPTION
## The problem

`log_run "completed"` records `duration_sec` and `exit_code`, so these two runs are byte-identical in `.claude-runs/YYYY-MM-DD.jsonl`:

- one that created a dev log, updated a project note and appended to the daily note
- one that read the summary, decided nothing was new, and never touched the vault

```json
{"run_id":"...","status":"completed","ts":...,"duration_sec":43,"exit_code":0}
```

The second is not an edge case. The prompt says *"If the summary contains nothing vault-worthy, exit without making any changes"*, and that is the common outcome whenever a session already recorded its own work by hand before compacting. So `exit_code: 0` was never evidence of a write, and the run log could not answer the question people open it to ask.

I hit this checking whether a compaction had actually propagated. The log said `completed, exit_code 0`; only diffing the vault's git history across the run's start and completion timestamps showed it had written nothing at all. The observability added so a run that declined to act would not be silent stops one level short: it records that the agent *ran*, not that it *did* anything.

## The change

Adds `files_changed` to the completed line:

```json
{"status":"completed","duration_sec":43,"exit_code":0,"files_changed":0}   // propagated nothing
{"status":"completed","duration_sec":51,"exit_code":0,"files_changed":3}   // wrote three notes
```

**Counted as file mtimes against a marker created at t0, not as a `git status --porcelain` delta.** A vault under the Obsidian Git plugin auto-commits on a timer; a commit landing mid-run drops the dirty count back to zero while leaving mtimes untouched, so a status delta would report "wrote nothing" for a productive run — precisely the failure this field exists to prevent. mtimes also need no git at all, so vaults that are not repos are covered.

Dot-prefixed names are pruned at every level, which keeps `.git`, `.obsidian`'s constantly-rewritten workspace state, and the hook's own `.claude-runs` and `.claude-lock` out of its own measurement.

## The part that is not obvious

A raw count is not enough on its own, and it took a real run against a scratch vault to see why.

**The headless agent this hook spawns is a full Claude Code session, so it loads this same skill**, and its own `SessionStart`/`SessionEnd` hooks write to whatever `OBSIDIAN_VAULT_PATH` points at while the propagation is running — boards, rollups, an index, a memory mirror. Pointing the hook at an empty scratch vault:

| written by | files |
| --- | ---: |
| the propagation itself (daily note, project note, dev log) | 3 |
| the spawned session's own machinery | 216 |

Against a live vault the same effect showed up as 8 files touched in 6 otherwise idle minutes, every one of them generated. A raw count therefore never reaches 0, and the field would read "8" for a run that propagated nothing while looking authoritative.

Hence `OBSIDIAN_BG_COUNT_IGNORE`: an extended regex matched against vault-relative paths, excluded from the count. **Unset by default** — the generated set is a property of a vault's layout, and guessing it for someone else's vault would be worse than counting everything. Documented in `hooks/postcompact.hook.example.json` next to the other env vars, with the warning that daily/project folders must stay *out* of the pattern since a write there is the signal.

## How to read the field

- **`0` is the trustworthy end**: nothing was written, by anyone.
- A nonzero value is a **direction, not an attribution** — any other writer active in the same window inflates it, and it can never prove this particular agent wrote a given file.
- It is **omitted entirely** when the count is unavailable (no marker, malformed regex), so it is never a guess. `grep` exits 1 when it filtered everything out and >=2 on a bad pattern; conflating those would turn a typo into a confident, wrong zero.

## Tests

Four tests added to `tests/test_bg_agent_hook.py`, in the existing stub-`claude` style:

- no-op run logs `files_changed: 0` (and the hook's own run log does not leak into it)
- a run that writes two notes logs `2`
- `OBSIDIAN_BG_COUNT_IGNORE` excludes generated paths and keeps the real one
- a malformed pattern omits the field rather than reporting `0` — written differentially, so it also asserts a *valid* pattern still produces a count, otherwise it would pass against any build that never emits the field

**All four fail on `main`.** Full suite: 579 passed.

Two small fixes to the shared `_run_hook` helper came with it: `OBSIDIAN_BG_COUNT_IGNORE` is now cleared alongside the other vars so a developer's exported environment cannot change results, and the stub takes explicit paths to write rather than a count — a `seq 1 $n` loop looks equivalent but BSD `seq 1 0` counts *down* and yields `1 0`, so the write-nothing case silently wrote two files and read as a hook bug.

## Not included

Nothing here changes when or whether the agent runs, what it is allowed to touch, or the `async`/detach behaviour of the spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
