### PR TITLE
Stop two overlapping compactions sharing one prompt file (BSD mktemp)

### DIFF
--- a/hooks/obsidian-bg-agent.sh
+++ b/hooks/obsidian-bg-agent.sh
@@ -129,7 +129,22 @@ fi
 # path as a symlink, since macOS does not enable protected_symlinks.
 BG_LOG="${TMPDIR:-/tmp}/obsidian-bg-agent-$(id -u).log"
 ( umask 077; : >> "$BG_LOG" ) 2>/dev/null || true
-PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/obsidian-bg-XXXXXX.txt")
+# No `.txt` suffix. BSD mktemp substitutes the X's ONLY when they end the
+# template, so `obsidian-bg-XXXXXX.txt` is a literal path on macOS and every run
+# shares one filename. GNU mktemp accepts a suffix, so this is invisible on
+# Linux and in CI. The first run creates that file and removes it only after its
+# agent exits, 40-190s later, so a compaction starting inside that window gets
+# "mkstemp failed: File exists", an empty PROMPT_FILE, three `cat > ""` failures
+# on stderr - which PostCompact shows to the user - and an agent launched with
+# no prompt at all, propagating nothing while the run log still says completed.
+PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/obsidian-bg-XXXXXX" 2>/dev/null || true)
+if [[ -z "$PROMPT_FILE" || ! -f "$PROMPT_FILE" ]]; then
+  # Fail as a recorded no-op instead of cascading into an agent with an empty
+  # prompt. Silent on stderr on purpose: this event surfaces stderr to a user
+  # who cannot act on it mid-compaction, so the run log is where it belongs.
+  log_run "no_prompt_file"
+  exit 0
+fi
 
 cat > "$PROMPT_FILE" << HEADER
 You are an autonomous Obsidian vault agent. The Claude session was just compacted.

--- a/tests/test_bg_agent_hook.py
+++ b/tests/test_bg_agent_hook.py
@@ -215,3 +215,104 @@ def test_launch_uses_strict_mcp_config(tmp_path):
         time.sleep(0.1)
     body = record.read_text(encoding="utf-8")
     assert "ARG=--strict-mcp-config" in body, "headless run must enforce filesystem-only MCP"
+
+
+def _fire_to_files(tmp_path: Path, tag: str, stdin: str, env: dict) -> tuple[int, str]:
+    """Run the hook with stdout/stderr going to FILES, not pipes.
+
+    Deliberate: the detached subshell inherits the hook's stdout and stderr, so
+    capture_output=True would keep those pipes open until the spawned agent
+    exits. subprocess.run would then block for the agent's whole lifetime, the
+    two runs below would never overlap, and the collision under test could not
+    happen - the test would pass against the bug it exists to catch.
+    """
+    out = tmp_path / f"out-{tag}.txt"
+    err = tmp_path / f"err-{tag}.txt"
+    with open(out, "w") as o, open(err, "w") as e:
+        r = subprocess.run(["bash", str(HOOK)], input=stdin, env=env, text=True,
+                           stdout=o, stderr=e, timeout=30)
+    return r.returncode, err.read_text(encoding="utf-8")
+
+
+def test_overlapping_runs_do_not_share_one_prompt_file(tmp_path):
+    """A second compaction while the first agent is still running must not
+    collide on the prompt file.
+
+    BSD mktemp substitutes the X's only when they END the template, so a
+    template carrying a suffix is a literal path on macOS and every run reuses
+    one filename. GNU mktemp accepts the suffix, so this passes on Linux and in
+    CI and fails only on a Mac, only when two runs overlap.
+
+    The burst-dedup lock does not cover this: its trap releases on hook exit,
+    under a second in, while the agent it spawned runs for minutes.
+
+    Two failures at once when they collide - stderr reaches the user, because
+    PostCompact surfaces stderr, and the second agent starts with an empty
+    prompt, so that compaction propagates nothing while its run log says
+    completed.
+    """
+    vault = tmp_path / "vault"; vault.mkdir()
+    stub_dir = tmp_path / "bin"; stub_dir.mkdir()
+    sizes = tmp_path / "prompt-sizes.txt"
+    stub = stub_dir / "claude"
+    # Record the prompt size, then stay alive so the next hook overlaps this one.
+    stub.write_text("#!/usr/bin/env bash\n"
+                    f'cat | wc -c | tr -d " " >> "{sizes}"\n'
+                    "sleep 3\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"isCompactSummary": True,
+                    "message": {"content": "a summary worth propagating"}}) + "\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}",
+           "OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1"}
+    stdin = json.dumps({"transcript_path": str(transcript)})
+
+    for tag in ("first", "second"):
+        code, err = _fire_to_files(tmp_path, tag, stdin, env)
+        assert code == 0, f"{tag} hook exited {code}"
+        assert err == "", f"{tag} run leaked stderr to the user:\n{err}"
+
+    lines: list[str] = []
+    for _ in range(30):
+        if sizes.exists():
+            lines = [l for l in sizes.read_text(encoding="utf-8").splitlines() if l.strip()]
+        if len(lines) == 2:
+            break
+        time.sleep(0.2)
+    assert len(lines) == 2, f"both compactions must reach an agent, got {lines}"
+    assert all(int(l) > 0 for l in lines), f"an agent was launched with an empty prompt: {lines}"
+
+
+def test_unusable_tmpdir_is_a_logged_no_op_not_a_cascade(tmp_path):
+    """When the prompt file cannot be created, stop and say so.
+
+    The failure mode being fenced off is a cascade: an empty PROMPT_FILE meant
+    `cat > ""` three times over, all of it on stderr and all of it shown to the
+    user mid-compaction, followed by an agent started with no prompt.
+    """
+    vault = tmp_path / "vault"; vault.mkdir()
+    stub_dir = tmp_path / "bin"; stub_dir.mkdir()
+    marker = tmp_path / "agent-ran.txt"
+    stub = stub_dir / "claude"
+    stub.write_text(f'#!/usr/bin/env bash\ncat > "{marker}"\n', encoding="utf-8")
+    stub.chmod(0o755)
+
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"isCompactSummary": True, "message": {"content": "did work"}}) + "\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}",
+           "OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1",
+           "TMPDIR": str(tmp_path / "does-not-exist")}
+    code, err = _fire_to_files(tmp_path, "notmp", json.dumps({"transcript_path": str(transcript)}), env)
+
+    assert code == 0, "an unusable TMPDIR must not fail the compaction"
+    assert err == "", f"nothing may reach the user's stderr:\n{err}"
+    assert not marker.exists(), "no agent may be launched without a prompt"
+    statuses = [e["status"] for e in _read_run_log(vault)]
+    assert "no_prompt_file" in statuses, f"the skip must be recorded, got {statuses}"


### PR DESCRIPTION
## The bug

```bash
PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/obsidian-bg-XXXXXX.txt")   # hooks/obsidian-bg-agent.sh:132
```

**BSD `mktemp` substitutes the `X`s only when they end the template.** With a suffix after them the path is taken literally:

```
$ mktemp "$TMPDIR/probe-XXXXXX.txt"
/var/folders/.../T//probe-XXXXXX.txt      <- literal, unsubstituted, identical every call

$ mktemp "$TMPDIR/probe2-XXXXXX"
/var/folders/.../T//probe2-LYwXbf         <- correct
```

GNU `mktemp` accepts a suffix, so this reads fine, works on Linux, and passes CI. It fails only on macOS, and only when two runs overlap — which is why it survived this long.

## What it costs when it hits

Every run on macOS uses the same filename. The first run creates it and removes it only after its agent exits, 40–190s later. Any compaction starting inside that window collides, and the failure cascades:

```
mktemp: mkstemp failed on /var/folders/.../T//obsidian-bg-XXXXXX.txt: File exists
hooks/obsidian-bg-agent.sh: line 134: : No such file or directory
hooks/obsidian-bg-agent.sh: line 144: : No such file or directory
hooks/obsidian-bg-agent.sh: line 159: : No such file or directory
hooks/obsidian-bg-agent.sh: line 228: : No such file or directory
```

Two distinct harms:

1. **That output reaches the user.** PostCompact is documented as *"Shows stderr to user only"*, so five lines of shell noise land in the middle of a compaction, about a temp file, with nothing the user can do.
2. **The compaction silently propagates nothing.** `PROMPT_FILE` is empty, so `cat > ""` fails three times, `claude -p < ""` gets no prompt, and the agent exits immediately — while the run log still records `{"status":"completed"}`. The failure is invisible in exactly the place someone would look for it.

The burst-dedup lock does not cover this. Its trap releases on hook exit, under a second in, while the agent it spawned keeps running for minutes — the comment on that lock says as much.

Observed in the wild on 2026-08-09: a run that exited 1 after one second, 41 seconds behind a still-running one. It was initially written off as a transient failure.

## The fix

Move the `X`s to the end, and make an uncreatable prompt file a recorded no-op instead of a cascade:

```bash
PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/obsidian-bg-XXXXXX" 2>/dev/null || true)
if [[ -z "$PROMPT_FILE" || ! -f "$PROMPT_FILE" ]]; then
  log_run "no_prompt_file"
  exit 0
fi
```

Silent on stderr on purpose — this event surfaces stderr to a user who cannot act on it mid-compaction, so the run log is the right place for it. That also fits the existing observability design in this script, where every decision not to propagate gets a JSONL line rather than a bare `exit 0`.

The temp file is an internal prompt buffer, so dropping the `.txt` costs nothing.

## Tests

Two added to `tests/test_bg_agent_hook.py`, **both fail on `main`**:

- `test_overlapping_runs_do_not_share_one_prompt_file` — fires the hook twice with a stub agent that stays alive, asserting neither run writes to stderr and both agents receive a non-empty prompt. On `main` it fails with the real message: `second run leaked stderr to the user: mktemp: mkstemp failed ... File exists`, and only one of the two agents ever gets a prompt.
- `test_unusable_tmpdir_is_a_logged_no_op_not_a_cascade` — points `TMPDIR` at a missing directory and asserts exit 0, empty stderr, no agent launched, and a `no_prompt_file` entry in the run log.

One detail worth flagging for anyone extending these: the tests send the hook's stdout and stderr to **files, not pipes**. The detached subshell inherits both, so `capture_output=True` keeps those pipes open until the spawned agent exits — `subprocess.run` would block for the agent's whole lifetime, the two runs would never overlap, and the test would pass against the very bug it exists to catch.

Full suite: 577 passed.

## Relationship to #198

Independent, and branched from `main` rather than stacked — either can merge first, in either order. #198 touches the run log's `completed` line; this touches prompt-file creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
