### PR TITLE
Give the spawned subshell its own stdio instead of the hook's

### DIFF
--- a/hooks/obsidian-bg-agent.sh
+++ b/hooks/obsidian-bg-agent.sh
@@ -231,6 +231,25 @@ log_run "starting" summary_chars "${#SUMMARY}" hints_chars "${#PROJECT_HINTS}"
   EXIT_CODE=$?
   rm -f "$PROMPT_FILE"
   log_run "completed" duration_sec "$(( $(date +%s) - START_TIME ))" exit_code "$EXIT_CODE"
-) &
+# Give the subshell its OWN stdio rather than inheriting the hook's, and detach
+# it from job control. `) &` alone leaves it holding the hook's stdout and
+# stderr for the agent's entire life - 40 to 190s for a real propagation run -
+# with two consequences:
+#
+#   1. Nothing reading the hook's output sees EOF until the AGENT exits, not
+#      until the hook exits. Measured against a 5s stub agent: a reader blocked
+#      6.00s without this redirect, 0.07s with it.
+#   2. Anything the subshell writes to stderr escapes to whoever is reading the
+#      hook - and PostCompact is documented as showing stderr to the user. That
+#      is not limited to the lines above: every future line added inside this
+#      block inherits the same exposure, which makes it a trap rather than a
+#      one-off. A failing `>> "$BG_LOG"` redirect is enough to put raw shell
+#      diagnostics in front of a user mid-compaction, about a temp file they
+#      have no way to act on.
+#
+# The agent's own output already goes to $BG_LOG, so nothing diagnostic is lost
+# here - this closes the gap around it.
+) </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
 
 exit 0

--- a/tests/test_bg_agent_hook.py
+++ b/tests/test_bg_agent_hook.py
@@ -215,3 +215,64 @@ def test_launch_uses_strict_mcp_config(tmp_path):
         time.sleep(0.1)
     body = record.read_text(encoding="utf-8")
     assert "ARG=--strict-mcp-config" in body, "headless run must enforce filesystem-only MCP"
+
+
+def _spawn_env(tmp_path: Path, vault: Path, stub_body: str, extra: dict | None = None) -> tuple[dict, str]:
+    stub_dir = tmp_path / "bin"; stub_dir.mkdir(exist_ok=True)
+    stub = stub_dir / "claude"
+    stub.write_text(stub_body, encoding="utf-8")
+    stub.chmod(0o755)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"isCompactSummary": True, "message": {"content": "did some work"}}) + "\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}",
+           "OBSIDIAN_VAULT_PATH": str(vault), "OBSIDIAN_BG_AGENT_ENABLED": "1",
+           **(extra or {})}
+    return env, json.dumps({"transcript_path": str(transcript)})
+
+
+def test_spawn_does_not_hold_the_hooks_stdio_open(tmp_path):
+    """The hook must return when IT is done, not when the agent is.
+
+    A backgrounded subshell inherits the parent's stdout and stderr, so anything
+    reading the hook's output sees EOF only once the agent exits - 40 to 190s
+    for a real propagation run, against a hook that otherwise returns in a
+    fraction of a second. Pipes here on purpose: with the output going to files
+    there is nothing to hold open and the regression is invisible.
+    """
+    vault = tmp_path / "vault"; vault.mkdir()
+    env, stdin = _spawn_env(tmp_path, vault, "#!/usr/bin/env bash\ncat >/dev/null\nsleep 5\n")
+    start = time.monotonic()
+    r = subprocess.run(["bash", str(HOOK)], input=stdin, env=env,
+                       capture_output=True, text=True, timeout=60)
+    elapsed = time.monotonic() - start
+    assert r.returncode == 0
+    assert elapsed < 2.0, (
+        f"hook took {elapsed:.2f}s against a 5s agent - its stdio is still held "
+        f"open by the spawned subshell"
+    )
+
+
+def test_subshell_stderr_never_reaches_the_user(tmp_path):
+    """Nothing the spawned block writes to stderr may surface to the user.
+
+    PostCompact is documented as showing stderr to the user, and this hook fires
+    mid-compaction, so a raw shell diagnostic about a temp file is both alarming
+    and unactionable. The exposure is not limited to today's lines: every future
+    line added inside that block inherits it, which is what makes an inherited
+    stderr a trap rather than a one-off.
+
+    Triggered here by making $BG_LOG a directory, so the subshell's
+    `>> "$BG_LOG"` redirect fails and bash reports it.
+    """
+    vault = tmp_path / "vault"; vault.mkdir()
+    fake_tmp = tmp_path / "tmp"; fake_tmp.mkdir()
+    (fake_tmp / f"obsidian-bg-agent-{os.getuid()}.log").mkdir()
+    env, stdin = _spawn_env(tmp_path, vault, "#!/usr/bin/env bash\ncat >/dev/null\n",
+                            {"TMPDIR": str(fake_tmp)})
+    r = subprocess.run(["bash", str(HOOK)], input=stdin, env=env,
+                       capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0, "an unusable log path must not fail the compaction"
+    assert r.stderr == "", f"the spawned block leaked to the user's stderr:\n{r.stderr}"


### PR DESCRIPTION
## The problem

```bash
) &
```

A backgrounded subshell inherits the parent's stdout and stderr. The hook returns in a fraction of a second, but those descriptors stay open until the **agent** exits — 40 to 190s for a real propagation run. Two consequences, both measured:

**1. Anything reading the hook's output blocks for the agent's lifetime, not the hook's.**

```
5s stub agent, reader on a pipe:
  ) &                            reader blocked 6.23s
  ) </dev/null >/dev/null 2>&1 & reader blocked 0.07s
```

The hook is designed to fire and forget — the comment above the spawn already says the subshell is detached and its exit code is never read. Holding the caller open for the agent's whole run contradicts that design.

**2. Anything the subshell writes to stderr surfaces to the user.**

`PostCompact` is documented as *"Shows stderr to user only"*, and this hook fires mid-compaction. The agent's own output is already redirected to `$BG_LOG`, so the intended output is safe — but everything *around* it in that block is not. A `>> "$BG_LOG"` redirect that fails is enough to put a raw shell diagnostic in front of someone, about a temp file they cannot act on.

The exposure is not limited to the lines there today. **Every future line added inside that block inherits it**, which is what makes an inherited stderr a trap rather than a one-off — a later `grep`, `find`, or `jq` added for bookkeeping becomes a user-facing error the first time its input is malformed.

## The change

```bash
) </dev/null >/dev/null 2>&1 &
disown 2>/dev/null || true
```

Give the subshell its own stdio instead of inheriting the hook's, and detach it from job control. Nothing diagnostic is lost: the agent's stdout and stderr already go to `$BG_LOG`, and every run outcome is already recorded in `$VAULT/.claude-runs/YYYY-MM-DD.jsonl`. This closes the gap around them rather than silencing anything.

`disown` is guarded (`2>/dev/null || true`) since it is a bashism that some `sh` implementations lack.

## Tests

Two added to `tests/test_bg_agent_hook.py`, **both failing on `main`** with the real symptom:

```
AssertionError: hook took 6.23s against a 5s agent - its stdio is still held open by the spawned subshell
AssertionError: the spawned block leaked to the user's stderr:
```

- `test_spawn_does_not_hold_the_hooks_stdio_open` — 5s stub agent, asserts the hook returns in under 2s. **Uses pipes deliberately:** send the output to files instead and there is nothing to hold open, so the regression becomes invisible and the test passes against the bug.
- `test_subshell_stderr_never_reaches_the_user` — makes `$BG_LOG` a directory so the subshell's append redirect fails, and asserts nothing reaches stderr while the compaction still succeeds.

Full suite: 577 passed.

## Relationship to the other two PRs

Independent in intent, all three branched off `main` rather than stacked, so any can merge first. This one and #198 both touch the region around the spawn, so whichever lands second may need a trivial rebase there — the changes do not overlap semantically.

- #198 — `files_changed` on the run log's completed line
- #199 — BSD `mktemp` collision between overlapping compactions
- this one — the spawn's stdio

🤖 Generated with [Claude Code](https://claude.com/claude-code)
