### PR TITLE
Fix validate-ai-first for VS Code create_file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`validate-ai-first` still enforced nothing useful in the VS Code Claude Code extension after it was wired into `hooks.json` (follow-up to #171, found by @born-in-autumn).** Stacked gaps: (1) the extension writes with `tool_name=create_file` and `tool_input.filePath` (camelCase) while the stock matcher only listed `Write|Edit|MultiEdit|NotebookEdit` and the script only read `file_path`, so the hook exited 0 with no warning; (2) after matcher/`filePath` were fixed, the hook did warn in the extension hook log (`NonBlockingError` / later Success + JSON) but the chat UI and the model still saw nothing - plain stderr + exit 1 is log-only, and `additionalContext` alone does not surface to the user. Matcher now includes `create_file`; path extraction accepts `filePath`; warnings exit 0 with JSON that carries `systemMessage` (user-visible per Claude Code hooks docs), plus `decision`/`reason` and `hookSpecificOutput.additionalContext` for the model path (stderr still mirrored for logs). Covered by `tests/test_smoke.py::test_validate_hook_accepts_vscode_extension_payload` and a matcher assertion in `tests/test_plugin_manifest.py`.
+
 ### Changed
 
 - **Improve spanish commands triggers** Native speaker audit of all 46 command triggers. Replaced literal translations with natural phrases people actually say, e.g., "ponme al tanto de todo" instead of "carga mi mundo". Improves trigger recognition for Spanish users without breaking routing precedence. (19 commands refined)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|create_file",
         "hooks": [
           {
             "type": "command",

--- a/hooks/validate-ai-first.hook.yaml
+++ b/hooks/validate-ai-first.hook.yaml
@@ -1,12 +1,12 @@
 name: validate-ai-first
 description: >
-  PostToolUse hook on Write and Edit. Warns when a markdown file inside
-  OBSIDIAN_VAULT_PATH fails the AI-first vault rule (missing required
+  PostToolUse hook on Write/Edit and create_file. Warns when a markdown file
+  inside OBSIDIAN_VAULT_PATH fails the AI-first vault rule (missing required
   frontmatter fields, missing 'For future Claude' preamble, broken YAML).
-  Non-blocking: the file write still succeeds; the agent sees the warning
-  in stderr and can choose to repair.
+  Non-blocking: the file write still succeeds; warning is returned as hook
+  JSON (systemMessage / additionalContext) so the host can surface it.
 script: validate-ai-first.sh
 triggers:
   - event: after-tool-use
-    match-tool: [write, edit]
+    match-tool: [write, edit, create_file]
 exclude: []

--- a/hooks/validate-ai-first.sh
+++ b/hooks/validate-ai-first.sh
@@ -2,9 +2,9 @@
 # =============================================================================
 # validate-ai-first.sh - Enforce the AI-first vault rule on Write/Edit
 # =============================================================================
-# Fires as a Claude Code PostToolUse hook after Write/Edit. Inspects the
-# written file and warns if it does not follow the AI-first rule defined in
-# references/ai-first-rules.md.
+# Fires as a Claude Code PostToolUse hook after Write/Edit (terminal) or
+# create_file (VS Code extension). Inspects the written file and warns if it
+# does not follow the AI-first rule defined in references/ai-first-rules.md.
 #
 # This is the write-time enforcement primitive: the vault stays AI-first
 # because every write is checked, not because future-Claude remembers all
@@ -30,15 +30,36 @@
 #   - Skips any file not ending in .md
 #
 # Exit codes:
-#   0 = pass (silent)
-#   1 = warn (issue surfaced; write is NOT reverted)
+#   0 = pass (silent), or warn via JSON on stdout (write is NOT reverted)
 # =============================================================================
+
+# Warn via Claude Code hook JSON (systemMessage + additionalContext). stderr
+# is mirrored for logs; exit 0 so the host parses stdout.
+emit_ai_first_warning() {
+  local msg="$1"
+  printf '%s\n' "$msg" >&2
+  jq -n --arg msg "$msg" '{
+    systemMessage: $msg,
+    decision: "block",
+    reason: $msg,
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: $msg
+    }
+  }'
+  exit 0
+}
 
 INPUT=$(cat)
 
-# Extract the written file path. Claude Code hook payload puts it at
-# .tool_input.file_path for Write and Edit.
-FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .args.file_path // ""' 2>/dev/null)
+# Write/Edit: tool_input.file_path. VS Code create_file: tool_input.filePath.
+FILE=$(printf '%s' "$INPUT" | jq -r '
+  .tool_input.file_path
+  // .tool_input.filePath
+  // .args.file_path
+  // .args.filePath
+  // ""
+' 2>/dev/null)
 
 # Bail silently on unparseable input or empty path
 [[ -z "$FILE" ]] && exit 0
@@ -78,11 +99,9 @@ WARNINGS=()
 # ── Check 1: frontmatter delimiters ──────────────────────────────────────────
 FIRST_LINE=$(head -1 "$FILE")
 if [[ "$FIRST_LINE" != "---" ]]; then
-  WARNINGS+=("$BASENAME has no frontmatter (expected --- on the first line). AI-first notes need date/type/tags/ai-first metadata.")
-  # Without frontmatter we can't run the other checks meaningfully — surface
+  # Without frontmatter we can't run the other checks meaningfully - surface
   # this single warning and exit.
-  printf 'AI-first warning: %s\n' "${WARNINGS[0]}" >&2
-  exit 1
+  emit_ai_first_warning "AI-first warning: $BASENAME has no frontmatter (expected --- on the first line). AI-first notes need date/type/tags/ai-first metadata."
 fi
 
 DELIMITER_COUNT=$(grep -c '^---$' "$FILE")
@@ -205,12 +224,12 @@ fi
 
 # ── Emit warnings ────────────────────────────────────────────────────────────
 if [[ ${#WARNINGS[@]} -gt 0 ]]; then
-  printf 'AI-first warnings on %s:\n' "$BASENAME" >&2
+  MSG="AI-first warnings on ${BASENAME}:"$'\n'
   for w in "${WARNINGS[@]}"; do
-    printf '  - %s\n' "$w" >&2
+    MSG+="  - ${w}"$'\n'
   done
-  printf '\nSee references/ai-first-rules.md for the full spec.\n' >&2
-  exit 1
+  MSG+=$'\n'"See references/ai-first-rules.md for the full spec."
+  emit_ai_first_warning "$MSG"
 fi
 
 exit 0

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -158,6 +158,11 @@ def test_plugin_hooks_reference_shipped_executable_scripts():
         for group in hooks["PostToolUse"]
         for hook in group["hooks"]
     ), "PostToolUse must wire validate-ai-first.sh - it is the write-time enforcement primitive"
+    matchers = " ".join(group.get("matcher", "") for group in hooks["PostToolUse"])
+    assert "create_file" in matchers, (
+        "PostToolUse matcher must include create_file - the VS Code Claude Code "
+        "extension writes with that tool name, not Write/Edit"
+    )
     for event, groups in hooks.items():
         for group in groups:
             for hook in group["hooks"]:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1049,9 +1049,9 @@ def test_mcp_search_supersedes_reverse_edge(tmp_path, monkeypatch):
 
 
 def test_validate_hook_flags_secrets(tmp_path):
-    """Check 6: real key material in a vault note must warn and exit 1; naming
-    a key by env-var NAME stays clean. High precision - prose about passwords
-    is not a finding."""
+    """Check 6: real key material in a vault note must warn via additionalContext;
+    naming a key by env-var NAME stays clean. High precision - prose about
+    passwords is not a finding."""
     hook = REPO_ROOT / "hooks/validate-ai-first.sh"
     frontmatter = "---\ntype: note\ndate: 2026-07-18\ntags: [t]\nai-first: true\n---\n\n## For future Claude\n\n"
 
@@ -1069,16 +1069,60 @@ def test_validate_hook_flags_secrets(tmp_path):
         )
 
     r_leaky = run(leaky)
-    assert r_leaky.returncode == 1
+    assert r_leaky.returncode == 0, r_leaky.stderr
+    leaky_out = json.loads(r_leaky.stdout)
+    assert "secret material" in leaky_out["systemMessage"]
+    assert leaky_out["decision"] == "block"
+    assert "secret material" in leaky_out["reason"]
+    assert "secret material" in leaky_out["hookSpecificOutput"]["additionalContext"]
     assert "secret material" in r_leaky.stderr
     r_clean = run(clean)
     assert r_clean.returncode == 0, r_clean.stderr
+    assert not r_clean.stdout.strip()
 
     # The bg-agent prompt must carry the sensitive-content staging constraint.
     bg = (REPO_ROOT / "hooks/obsidian-bg-agent.sh").read_text(encoding="utf-8")
     assert "SENSITIVE CONTENT" in bg
     assert "NEVER" in bg and "staging" in bg.lower()
 
+
+def test_validate_hook_accepts_vscode_extension_payload(tmp_path):
+    """VS Code Claude Code writes via create_file + tool_input.filePath.
+    Without that alias the hook fires, finds no path, and exits 0 silently -
+    so the AI-first rule enforces nothing in the extension (claude-code owner).
+
+    Warnings must be exit-0 JSON: systemMessage for the user, decision/reason
+    + additionalContext for the model. Plain stderr + exit 1 only hits the
+    extension hook log as NonBlockingError and never surfaces in chat."""
+    hook = REPO_ROOT / "hooks/validate-ai-first.sh"
+    bad = tmp_path / "bad.md"
+    bad.write_text("# bad note\njust a test\n", encoding="utf-8")
+
+    def run(payload: dict):
+        return subprocess.run(
+            ["bash", str(hook)],
+            input=json.dumps(payload),
+            env=dict(os.environ, OBSIDIAN_VAULT_PATH=str(tmp_path)),
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_warn(result):
+        assert result.returncode == 0, result.stderr
+        assert "AI-first warning" in result.stderr
+        assert "frontmatter" in result.stderr
+        out = json.loads(result.stdout)
+        assert "AI-first warning" in out["systemMessage"]
+        assert "frontmatter" in out["systemMessage"]
+        assert out["decision"] == "block"
+        assert "AI-first warning" in out["reason"]
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        assert "AI-first warning" in ctx
+        assert "frontmatter" in ctx
+
+    assert_warn(run({"tool_name": "Write", "tool_input": {"file_path": str(bad)}}))
+    assert_warn(run({"tool_name": "create_file", "tool_input": {"filePath": str(bad)}}))
 
 def test_recall_hook_contract(tmp_path):
     """Bounded recall: inert without the double gate, injects a bounded brief


### PR DESCRIPTION
## What this PR does

Makes the write-time AI-first validator work in the VS Code Claude Code extension: match `create_file` / `filePath`, and return Claude Code hook JSON (`systemMessage` + model feedback) so warnings show in the chat UI instead of only in hook logs. Follow-up to #171.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📜 New slash command
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor / cleanup
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)

## Related issues

Related to #171 (validator was wired into `hooks.json`, but the VS Code write path still did not surface warnings).

## How I tested it

**Automated**

- `uv run pytest -q tests/test_smoke.py::test_validate_hook_accepts_vscode_extension_payload tests/test_smoke.py::test_validate_hook_flags_secrets tests/test_plugin_manifest.py`
- Dual payload: CLI-shaped `{tool_name: Write, tool_input.file_path}` and extension-shaped `{tool_name: create_file, tool_input.filePath}` both return exit 0 + JSON with `systemMessage` / `additionalContext` containing `AI-first warning` + frontmatter text. Clean notes stay silent (exit 0, empty stdout).

**Manual - VS Code Claude Code extension** (vault workspace)

- Wrote a deliberate bad note via `create_file` (no frontmatter, no `## For future Claude`).
- Before this fix: model reported `AI-first warning seen: NONE` while Hooks.log either skipped the tool or logged stderr-only `NonBlockingError`.
- After this fix: Hooks.log shows PostToolUse `Success` with the JSON payload; chat surfaces `AI-first warning: ... has no frontmatter ...`.

**Manual - terminal Claude Code CLI** (regression after JSON change)

- From vault cwd, `Write` to `Inbox/hook-cli-write-retest.md` with exactly `# bad note` / `just a test` (no frontmatter, no `## For future Claude`).
- Host reported: `PostToolUse:Write hook returned blocking error` and the model quoted verbatim:
  `AI-first warning: hook-cli-write-retest.md has no frontmatter (expected --- on the first line). AI-first notes need date/type/tags/ai-first metadata.`
- File write still succeeded (non-blocking for the vault content; warning is feedback only).

## AI-first rule compliance (required for any vault-writing command)

- [x] My changes follow `references/ai-first-rules.md`
- [ ] If I added or changed a command that writes to the vault, the produced note has a `## For future Claude` preamble
- [ ] Frontmatter includes `ai-first: true`, `type:`, `date:`, `tags:`
- [ ] Wikilinks (`[[...]]`) used for every person, project, idea, decision referenced
- [ ] External claims have recency markers (`(as of YYYY-MM, source.com)`)
- [ ] Sources preserved verbatim (URLs inline, not paraphrased)

N/A for the unchecked items: this PR only changes the PostToolUse validator hook (how warnings are matched and surfaced). It does not add or change a vault-writing slash command.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [ ] I updated the README or docs if user-facing behavior changed
- [x] I updated `CHANGELOG.md` (under "Unreleased") if applicable
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table

No README/SKILL updates: no new command; behavior fix is documented in CHANGELOG + hook yaml.

## Screenshots / output (if visual or producing notes)
Terminal CLI after bad `Write`: 「PostToolUse:Write hook returned blocking error AI-first warning: hook-cli-write-retest.md has no frontmatter (expected --- on the first line). AI-first notes need date/type/tags/ai-first metadata.」
VS Code: Hooks.log PostToolUse Success + JSON; chat quotes the same `AI-first warning: ...` line.



