### PR TITLE
Fix MCP server failing to register any tool under mcp<2

### DIFF
--- a/integrations/obsidian-mcp-server/server.py
+++ b/integrations/obsidian-mcp-server/server.py
@@ -12,7 +12,28 @@ Run:
 or wire it into a client's MCP config (see README.md).
 """
 
-from __future__ import annotations
+# DO NOT add `from __future__ import annotations` to this module.
+#
+# Symptom if you do: the server dies during startup and the client lists zero
+# vault tools, with "issubclass() arg 1 must be a class" in the logs.
+#
+# Cause: PEP 563 turns every annotation in this module into a plain string.
+# fastmcp inspects each tool's signature at registration time and calls
+# `issubclass(param.annotation, Context)` to find the context parameter.
+# `issubclass` needs a real class, so a string annotation raises TypeError on
+# the FIRST @mcp.tool() it walks, which aborts registration for all of them.
+#
+# This is a fastmcp limitation, not a defect in this file. Annotations below
+# are therefore evaluated eagerly at import time, so every name used in an
+# annotation on a decorated function must be importable at module scope
+# (no `if TYPE_CHECKING:` guarded names in those positions).
+#
+# Note that the `mcp<2` pin in .claude-plugin/plugin.json does not prevent
+# this: `mcp<2` resolves to 1.9.4, which is precisely the fastmcp that trips
+# on string annotations. The pin guards against the 2.x rewrite dropping
+# `mcp.server.fastmcp` entirely; it does not guard against this. If the pin is
+# ever lifted to 2.x, recheck whether the issubclass path was fixed there, in
+# which case this import can come back.
 
 import json
 import sys


### PR DESCRIPTION
## What breaks

Connecting the bundled Obsidian MCP server fails on a clean install. The server
exits during startup and the client lists zero `vault` tools. The log shows:

```
TypeError: issubclass() arg 1 must be a class
```

## Cause

`integrations/obsidian-mcp-server/server.py` opens with
`from __future__ import annotations`. Under PEP 563 that turns every annotation
in the module into a plain string.

fastmcp inspects each tool's signature at registration time to locate the
context parameter, using `issubclass(param.annotation, Context)`. `issubclass`
requires a real class, so a string annotation raises `TypeError` on the first
`@mcp.tool()` it walks, aborting registration for every tool in the module.

This is a fastmcp limitation rather than a defect in this file.

## Why the `mcp<2` pin does not already cover it

#185 pinned the launch to `mcp<2` so an SDK release could not take every install
down. That pin is correct and is left alone here, but it addresses a different
failure: the 2.x rewrite removed `mcp.server.fastmcp` outright, so the module
cannot import at all.

`mcp<2` resolves to 1.9.4, and 1.9.4 is precisely the fastmcp whose
registration path trips on string annotations. So the crash described above is
still reachable on current `main` with the pin in place.

## The change

One line removed, plus a comment in its place.

The comment is deliberately long because a bare missing `from __future__ import
annotations` reads as an oversight, and a later cleanup pass would reasonably
re-add it. It records the user-visible symptom, the mechanism, the constraint
this puts on annotations in this module (every name used in an annotation on a
decorated function must be importable at module scope, so no `TYPE_CHECKING`
guarded names in those positions), and the condition under which the import can
come back.

## Testing

- `uvx ruff check .` passes
- `uv run pytest -q` passes, 626 tests
- Server verified starting and registering tools against a live vault under
  `mcp<2`

## Notes

- No behavior change to any command and no change to vault output.
  `references/ai-first-rules.md` is untouched.
- Rebased onto current `main` (`c93ce3f`). An earlier revision of this PR also
  proposed pinning `mcp==1.9.4`; that has been dropped, since #185 already
  solved that problem with a range and the range is the better call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeXeS651sAswV4artBendJ
