### PR TITLE
Say on stderr when a research daily-note or log append is skipped (follow-up to #248 / #252 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **A skipped daily-note or log append now says so on stderr (follow-up to #248, asked for in the #252 review).** `append_to_daily` and `append_to_log` already refused to touch a file that is not valid UTF-8 (a note an earlier Windows run rewrote in its code page), and `append_to_daily` returned `False` when there is no daily note for today - but every caller ignores the return value and the research note is saved by then, so the run looked like a silent success. Each refusal now prints one `[vault] ...` line naming the file and the one-time fix (re-save as UTF-8), in the style of the toolkit's other stderr notes. Nothing else changes: the file is still left exactly as it was. Tests pin all three lines.
+
 ## [0.15.0] - 2026-09-04 - The Port
 
 ### Added

--- a/scripts/research/lib/vault.py
+++ b/scripts/research/lib/vault.py
@@ -11,6 +11,7 @@ Each note follows the AI-first vault rule:
 """
 
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -136,13 +137,20 @@ def append_to_log(operation_summary: str) -> bool:
 
     A log that is not UTF-8 (one an earlier Windows run wrote in its code page)
     is left exactly as it is, as append_to_daily does: UTF-8 bytes appended to
-    it would leave a file that decodes correctly as neither encoding.
+    it would leave a file that decodes correctly as neither encoding. The
+    refusal is said on stderr, so a run that saved its note but changed no log
+    does not look like a silent success.
     """
     log_path = VAULT_PATH / "log.md"
     if log_path.exists():
         try:
             log_path.read_bytes().decode("utf-8")
         except UnicodeDecodeError:
+            print(
+                "[vault] log.md is not UTF-8 - left untouched, nothing appended. "
+                "Re-save it as UTF-8 once (see the README FAQ) and re-run.",
+                file=sys.stderr,
+            )
             return False
     date = datetime.now().strftime("%Y-%m-%d")
     entry = f"\n## [{date}] research-toolkit | {operation_summary}\n"
@@ -152,16 +160,31 @@ def append_to_log(operation_summary: str) -> bool:
 
 
 def append_to_daily(summary_md: str) -> bool:
-    """Append a research summary to today's daily note. Returns True if appended."""
+    """Append a research summary to today's daily note. Returns True if appended.
+
+    Both reasons for not appending - no daily note for today, or a daily note
+    that is not UTF-8 - are said on stderr, since callers ignore the return
+    value and the research note itself has already been saved by then.
+    """
     date = datetime.now().strftime("%Y-%m-%d")
     daily_path = VAULT_PATH / "wiki" / "daily" / f"{date}.md"
     if not daily_path.exists():
+        print(
+            f"[vault] no daily note at {daily_path.relative_to(VAULT_PATH)} - "
+            "research summary not appended (the research note itself is saved).",
+            file=sys.stderr,
+        )
         return False
     try:
         current = daily_path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
         # Not UTF-8 (a note an earlier Windows run rewrote in its code page):
         # leave it as it is rather than rewrite it lossily, as note_io's rule says.
+        print(
+            f"[vault] {daily_path.name} is not UTF-8 - left untouched, research summary "
+            "not appended. Re-save it as UTF-8 once (see the README FAQ) and re-run.",
+            file=sys.stderr,
+        )
         return False
     block = f"\n### Research - {datetime.now().strftime('%H:%M')}\n\n{summary_md.strip()}\n"
     if "## 🌙 Evening Review" in current:

--- a/tests/test_research_cjk_and_models.py
+++ b/tests/test_research_cjk_and_models.py
@@ -167,7 +167,7 @@ def test_vault_writes_are_utf8_under_a_cp1252_default(tmp_path, monkeypatch, cp1
     assert text in saved.read_bytes().decode("utf-8")
 
 
-def test_append_to_daily_leaves_a_note_it_cannot_decode_alone(tmp_path, monkeypatch):
+def test_append_to_daily_leaves_a_note_it_cannot_decode_alone(tmp_path, monkeypatch, capsys):
     """A daily note an earlier Windows run rewrote in its code page is not UTF-8.
     Reading it strictly would raise where the old code silently continued, and
     reading it forgivingly would save U+FFFD over every such byte; the appender
@@ -183,9 +183,12 @@ def test_append_to_daily_leaves_a_note_it_cannot_decode_alone(tmp_path, monkeypa
     daily.write_bytes(legacy)
     assert vault.append_to_daily("more") is False
     assert daily.read_bytes() == legacy
+    # The refusal is not silent: the command's stderr names the file and the fix.
+    err = capsys.readouterr().err
+    assert "2026-09-02.md is not UTF-8" in err and "not appended" in err
 
 
-def test_append_to_log_leaves_a_log_it_cannot_decode_alone(tmp_path, monkeypatch):
+def test_append_to_log_leaves_a_log_it_cannot_decode_alone(tmp_path, monkeypatch, capsys):
     """The same rule for log.md: UTF-8 appended to a log an earlier Windows run
     wrote in its code page would leave bytes that decode as neither encoding,
     so the appender declines and the file stays exactly as it was."""
@@ -198,6 +201,8 @@ def test_append_to_log_leaves_a_log_it_cannot_decode_alone(tmp_path, monkeypatch
     (root / "log.md").write_bytes(legacy)
     assert vault.append_to_log("more") is False
     assert (root / "log.md").read_bytes() == legacy
+    err = capsys.readouterr().err
+    assert "log.md is not UTF-8" in err and "nothing appended" in err
 
 
 def test_no_stale_tokenizer_copies_left_in_command_paths():
@@ -360,3 +365,19 @@ def test_ladder_exhaustion_names_the_env_fix(gemini, monkeypatch):
     with pytest.raises(RuntimeError) as e:
         gemini.call("hi", command="test")
     assert "GEMINI_SUMMARY_MODEL" in str(e.value)
+
+
+def test_append_to_daily_says_when_there_is_no_daily_note(tmp_path, monkeypatch, capsys):
+    """The other silent skip: no daily note for today. Callers ignore the False
+    and the research note is already saved, so without a stderr line a user
+    sees a saved note and an unchanged (or absent) daily note with no hint why."""
+    from research.lib import vault
+
+    root = tmp_path / "vault"
+    root.mkdir()
+    monkeypatch.setattr(vault, "VAULT_PATH", root)
+    monkeypatch.setattr(vault, "datetime", _Noon)
+    assert vault.append_to_daily("more") is False
+    err = capsys.readouterr().err
+    assert "no daily note at" in err and "2026-09-02.md" in err
+    assert not (root / "wiki" / "daily" / "2026-09-02.md").exists()


### PR DESCRIPTION
## What this PR does

The #252 review noted: "command output is still silent when the append is skipped." `append_to_daily` and `append_to_log` refuse to touch a file that is not valid UTF-8 (#248), and `append_to_daily` returns `False` when there is no daily note for today - but every caller (`research.py`, `research_deep.py`, `x_pulse.py`, `youtube_extract.py`, `podcast_extract.py`) ignores the return value, and the research note is already saved by then. Each refusal now prints one `[vault] ...` line on stderr naming the file and the one-time fix, in the style of the toolkit's other stderr notes (`aggregator.py`, `groq.py`). The file is still left exactly as it was; nothing else changes.

If this lands before #252, the FAQ sentence there ("and nothing says so in the command output") should read "and a `[vault]` line on stderr says so" - I will update whichever lands second.

## Type of change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related issues

Related to #248 and #252 (review comment). n/a for a dedicated issue - the reviewer named the gap.

## How I tested it

- Extended the two #248 tests (`test_append_to_daily_leaves_a_note_it_cannot_decode_alone`, `test_append_to_log_leaves_a_log_it_cannot_decode_alone`) to assert the stderr line via `capsys`, and added `test_append_to_daily_says_when_there_is_no_daily_note`. `pytest tests/test_research_cjk_and_models.py`: 14 passed.
- `ruff check` clean; `sweep_non_ascii.py --check` clean.

## AI-first rule compliance (required for any vault-writing command)

n/a - no note content changes; the appenders only report when they decline to write.

## Checklist

- [x] I searched existing issues and PRs before opening this one
- [x] My commit messages are descriptive (focus on WHY, not just WHAT)
- [ ] I updated the README or docs if user-facing behavior changed - the FAQ wording lives in #252; see note above
- [x] I updated `CHANGELOG.md` (under "Unreleased") if applicable
- [ ] If I added a new command, I added an entry in `SKILL.md` and the README's command table (n/a)