### PR TITLE
Fix FRESH-3 false positives on RDF CURIEs and URL path segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **`freshness_lint.py` FRESH-3 no longer fires on RDF CURIEs or on `prefix:token` segments inside URLs.** `owl:Class`, `rdfs:label`, `skos:broader` name terms in a vocabulary, not records in a home system, so `owl`, `rdf`, `rdfs`, `xsd`, `skos`, `foaf`, `dc`, `dcterms`, `schema`, `prov`, `sh`, `dbo` and `wdt` join `POINTER_IGNORE`; and URLs are dropped from the line before the pointer scan, because a path segment such as Medium's `/resize:fit:1400/` matched the pointer shape while the URL guard only inspected the match itself. On a 6,400-note research vault this removed 126 findings, all false; a real unmapped id (`linear:ABC-123`) still rings. Covered by `tests/test_freshness_lint.py`.
+
 ## [0.15.0] - 2026-09-04 - The Port
 
 ### Added

--- a/scripts/freshness_lint.py
+++ b/scripts/freshness_lint.py
@@ -137,7 +137,12 @@ URL = re.compile(r"https?://\S+")
 HEADING = re.compile(r"^(#{1,6})\s")
 # Typed-pointer prefixes that are just URI schemes or common false positives.
 POINTER_IGNORE = {"http", "https", "mailto", "file", "obsidian", "tel", "ftp",
-                  "note", "example", "type", "status", "date", "source"}
+                  "note", "example", "type", "status", "date", "source",
+                  # RDF / ontology vocabulary prefixes (owl:Class, rdfs:label,
+                  # skos:broader): CURIEs name terms in a vocabulary, not a record
+                  # in a home system, so there is nothing to map or refresh.
+                  "owl", "rdf", "rdfs", "xsd", "skos", "foaf", "dc", "dcterms",
+                  "schema", "prov", "sh", "dbo", "wdt"}
 
 
 def parse_frontmatter(lines: list[str]) -> tuple[dict, int]:
@@ -265,7 +270,12 @@ def lint_file(path: Path, rel: str, cfg: dict, today: date) -> list[dict]:
         stripped = HTML_COMMENT.sub("", stripped)
 
         # FRESH-3: typed pointers must be mapped (URLs are always fine).
-        for pm in TYPED_POINTER.finditer(stripped):
+        # Drop URLs before scanning: a path segment such as Medium's
+        # `/resize:fit:1400/` inside a URL matched the pointer shape and rang
+        # FRESH-3 on every image link, while the URL guard below only sees the
+        # match itself.
+        pointer_text = URL.sub(" ", stripped)
+        for pm in TYPED_POINTER.finditer(pointer_text):
             prefix = pm.group(1).lower()
             if prefix in POINTER_IGNORE or URL.search(pm.group(0)):
                 continue

--- a/tests/test_freshness_lint.py
+++ b/tests/test_freshness_lint.py
@@ -318,3 +318,18 @@ def test_findings_name_files_with_forward_slashes():
     assert "\\" in str(note), "sanity: this is the form the finding used to carry"
     assert _report_path(note, root) == "Boards/Work.md"
     assert _report_path(root / "note.md", root) == "note.md"
+
+
+def test_fresh3_ignores_curies_and_url_path_segments(tmp_path):
+    """RDF-style CURIEs (owl:Class, rdfs:label) name vocabulary terms, not records in a
+    home system, and `prefix:token` segments inside a URL (Medium's /resize:fit:1400/)
+    are not pointers either. Both rang FRESH-3 on a research vault (126 findings, all
+    false) before this exemption. A real unmapped id still rings."""
+    write(tmp_path, "onto.md",
+          "# Onto\n\nThe class is declared as owl:Class with rdfs:label and skos:broader links.\n"
+          "![figure](https://miro.medium.com/v2/resize:fit:1400/format:webp/abc.png)\n"
+          "Tracked in linear:ABC-123 as well.\n")
+    report = lint_folder(tmp_path, today=TODAY)
+    hits = rules(report, "FRESH-3")
+    assert [h["text"] for h in hits] == [
+        "typed pointer 'linear:ABC-123' has no mapping in .freshness.json"]


### PR DESCRIPTION
## What

`scripts/freshness_lint.py` FRESH-3 (typed pointer with no mapping) rang on two kinds of text that are not pointers:

- RDF / ontology CURIEs: `owl:Class`, `rdfs:label`, `skos:broader`, `dcterms:creator`. These name terms in a vocabulary, not records in a home system, so there is nothing to map or refresh. The common prefixes now join `POINTER_IGNORE`.
- `prefix:token` segments inside URLs, e.g. Medium image links `https://miro.medium.com/v2/resize:fit:1400/format:webp/...`. The existing URL guard only inspected the regex match itself, so the segment slipped through. URLs are now dropped from the line before the pointer scan.

## Why

Running the lint on a 6,400-note research vault (maritime engineering + AI/ML, many ontology notes and clipped Medium articles) produced 139 findings, of which 126 were FRESH-3 and all 126 were these two shapes. The 13 FRESH-1 findings were genuine and useful.

## Test

`tests/test_freshness_lint.py::test_fresh3_ignores_curies_and_url_path_segments`: CURIEs and a Medium URL on the same note as an unmapped `linear:ABC-123`; only the latter rings. `pytest tests/test_freshness_lint.py` and `ruff check` pass. CHANGELOG entry under Unreleased.

Context: from a research domain fork (ECOSYSTEM.md pattern) that runs the lint nightly from a scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)